### PR TITLE
pkg/topology: add types for tracking service topology

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,8 @@ formatters:
       sections:
         - standard
         - default
+        - prefix(k8s.io)
+        - prefix(sigs.k8s.io)
         - prefix(github.com/Azure)
         - blank
         - dot

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.32.3
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -54,7 +55,7 @@ require (
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.6 // indirect
 	github.com/dave/dst v0.27.3 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -75,7 +76,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
@@ -134,7 +135,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polyfloyd/go-errorlint v1.7.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,9 @@ github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEy
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
@@ -243,8 +244,8 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 h1:WUvBfQL6EW/40l6OmeSBYQJNSif4O11+bmWEz+C7FYw=
 github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32/go.mod h1:NUw9Zr2Sy7+HxzdjIULge71wI6yEg1lWQr7Evcu8K0E=
 github.com/golangci/go-printf-func-name v0.1.0 h1:dVokQP+NMTO7jwO4bwsRwLWeudOVUPPyAKJuzv8pEJU=
@@ -449,8 +450,9 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.7.1 h1:RyLVXIbosq1gBdk/pChWA8zWYLsq9UEw7a1L5TVMCnA=
 github.com/polyfloyd/go-errorlint v1.7.1/go.mod h1:aXjNb1x2TNhoLsk26iv1yl7a+zTnXPhwEMtEXukiLR8=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
@@ -991,6 +993,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.6.1 h1:R094WgE8K4JirYjBaOpz/AvTyUu/3wbmAoskKN/pxTI=
 honnef.co/go/tools v0.6.1/go.mod h1:3puzxxljPCe8RGJX7BIy1plGbxEOZni5mR2aXe3/uk4=
+k8s.io/apimachinery v0.32.3 h1:JmDuDarhDmA/Li7j3aPrwhpNBA94Nvk5zLeOge9HH1U=
+k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 mvdan.cc/gofumpt v0.7.0 h1:bg91ttqXmi9y2xawvkuMXyvAA/1ZGJqYAEGjXuP0JXU=
 mvdan.cc/gofumpt v0.7.0/go.mod h1:txVFJy/Sc/mvaycET54pV8SW8gWxTlUuGHVEcncmNUo=
 mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 h1:WjUu4yQoT5BHT1w8Zu56SP8367OuBV5jvo+4Ulppyf8=

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -1,0 +1,133 @@
+package topology
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/yaml"
+)
+
+type Topology struct {
+	// Services holds the root nodes for service dependency trees.
+	Services []Service `json:"services,omitempty"`
+
+	// Entrypoints selects specific sub-trees that are deployed together.
+	Entrypoints []Entrypoint `json:"entrypoints,omitempty"`
+}
+
+// Service describes an individual service in the tree.
+type Service struct {
+	// ServiceGroup is the identifier for this service.
+	ServiceGroup string `json:"serviceGroup"`
+
+	// Children holds any dependent services.
+	Children []Service `json:"children,omitempty"`
+
+	// Metadata is an extension point to store useful information for the service.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Entrypoint describes an individual pipeline in the tree.
+type Entrypoint struct {
+	// Identifier is the root of the sub-tree selected by this entrypoint.
+	Identifier string `json:"identifier"`
+
+	// Metadata is an extension point to store useful information for the sub-tree.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func Load(path string) (*Topology, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var out Topology
+	return &out, yaml.Unmarshal(raw, &out)
+}
+
+func (t *Topology) Validate() error {
+	return (&validator{
+		seen:       sets.New[string](),
+		duplicates: sets.New[string](),
+	}).validate(t)
+}
+
+type validator struct {
+	seen       sets.Set[string]
+	duplicates sets.Set[string]
+}
+
+func (v *validator) validate(t *Topology) error {
+	for _, root := range t.Services {
+		v.walk(root)
+	}
+
+	var messages []string
+	if v.duplicates.Len() > 0 {
+		messages = append(messages, fmt.Sprintf("the following pipelines had duplicate entries: %v", sets.List(v.duplicates)))
+	}
+	for _, entrypoint := range t.Entrypoints {
+		if entrypoint.Identifier == "" {
+			messages = append(messages, "entrypoint identifier cannot be empty")
+		}
+		if !v.seen.Has(entrypoint.Identifier) {
+			messages = append(messages, fmt.Sprintf("entrypoint %s was not found in the dependency tree", entrypoint.Identifier))
+		}
+	}
+	if len(messages) > 0 {
+		return fmt.Errorf("dependency tree invalid: %s", strings.Join(messages, ", "))
+	}
+	return nil
+}
+
+func (v *validator) walk(s Service) {
+	if v.seen.Has(s.ServiceGroup) {
+		v.duplicates.Insert(s.ServiceGroup)
+	}
+	v.seen.Insert(s.ServiceGroup)
+	for _, child := range s.Children {
+		v.walk(child)
+	}
+}
+
+// ServiceNotFoundError denotes a failure in Lookup() when the requested service group is not in the tree.
+type ServiceNotFoundError struct {
+	ServiceGroup string
+}
+
+func (e *ServiceNotFoundError) Error() string {
+	return fmt.Sprintf("service group %s not found in service tree", e.ServiceGroup)
+}
+
+// Lookup determines if the serviceGroup in question is part of the service topology tree and returns a pointer to the root
+// node, if so.
+func (t *Topology) Lookup(serviceGroup string) (*Service, error) {
+	// walk the dependency tree from the roots; if we find the serviceGroup we know it's part of build-out
+	var service *Service
+	for i := range t.Services {
+		if found := find(&t.Services[i], serviceGroup); found != nil {
+			service = found
+			break
+		}
+	}
+	if service == nil {
+		return nil, &ServiceNotFoundError{ServiceGroup: serviceGroup}
+	}
+	return service, nil
+}
+
+func find(root *Service, identifier string) *Service {
+	if root.ServiceGroup == identifier {
+		return root
+	}
+	for i := range root.Children {
+		if found := find(&root.Children[i], identifier); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/pkg/topology/types_test.go
+++ b/pkg/topology/types_test.go
@@ -1,0 +1,194 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestValidate(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		input string
+		err   bool
+	}{
+		{
+			name: "happy path",
+			input: `entrypoints:
+- identifier: a.b.c
+services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.C
+- serviceGroup: A.B`,
+			err: false,
+		},
+		{
+			name: "duplicate service group",
+			input: `entrypoints:
+- identifier: a.b.c
+services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.c.d
+- serviceGroup: A.B`,
+			err: true,
+		},
+		{
+			name: "missing entrypoint",
+			input: `entrypoints:
+- identifier: a.b.c.d.e
+services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.c.d
+- serviceGroup: A.B`,
+			err: true,
+		},
+		{
+			name: "empty identifier",
+			input: `entrypoints:
+- identifier: ''
+services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.c.d
+- serviceGroup: A.B`,
+			err: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var topo Topology
+			if err := yaml.Unmarshal([]byte(testCase.input), &topo); err != nil {
+				t.Fatalf("failed to unmarshal: %s", err)
+			}
+			err := topo.Validate()
+			if err == nil && testCase.err {
+				t.Errorf("expected error, got none")
+			}
+			if err != nil && !testCase.err {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDependency_Lookup(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		input      string
+		identifier string
+		expected   *Service
+		err        bool
+		notFound   bool
+	}{
+		{
+			name: "missing",
+			input: `services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.C
+- serviceGroup: A.B`,
+			identifier: "1.2.3",
+			err:        true,
+			notFound:   true,
+		},
+		{
+			name: "top-level",
+			input: `services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.C
+- serviceGroup: A.B`,
+			identifier: "a.b",
+			expected: &Service{
+				ServiceGroup: "a.b",
+				Children: []Service{
+					{
+						ServiceGroup: "a.b.c",
+						Children: []Service{
+							{
+								ServiceGroup: "a.b.c.d",
+							},
+						},
+					},
+					{
+						ServiceGroup: "a.b.C",
+					},
+				},
+			},
+		},
+		{
+			name: "mid-level",
+			input: `services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.C
+- serviceGroup: A.B`,
+			identifier: "a.b.c",
+			expected: &Service{
+				ServiceGroup: "a.b.c",
+				Children: []Service{
+					{
+						ServiceGroup: "a.b.c.d",
+					},
+				},
+			},
+		},
+		{
+			name: "leaf",
+			input: `services:
+- serviceGroup: a.b
+  children:
+  - serviceGroup: a.b.c
+    children:
+    - serviceGroup: a.b.c.d
+  - serviceGroup: a.b.C
+- serviceGroup: A.B`,
+			identifier: "a.b.c.d",
+			expected: &Service{
+				ServiceGroup: "a.b.c.d",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var topo Topology
+			if err := yaml.Unmarshal([]byte(testCase.input), &topo); err != nil {
+				t.Fatalf("failed to unmarshal: %s", err)
+			}
+			build, err := topo.Lookup(testCase.identifier)
+			if err == nil && testCase.err {
+				t.Errorf("expected error, got none")
+			}
+			if err != nil && !testCase.err {
+				t.Errorf("expected no error, got: %v", err)
+			}
+			if diff := cmp.Diff(build, testCase.expected); diff != "" {
+				t.Errorf("build: (-want got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We would like to track the overall topology of the serivces that make up ARO-HCP. Not only do we want to track each individual service and the dependencies it has on other services, but we want to annotate them with metadata to allow us to auto-generate nice documentation on the serve tree. In addition, we anticipate generating a pipeline per service as well as aggregate pipelines that deploy a sub-tree of services all at once.