### PR TITLE
Move aksCluster attribute

### DIFF
--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 
@@ -41,12 +40,7 @@ func NewPipelineFromFile(pipelineFilePath string, cfg config.Configuration) (*Pi
 		return nil, fmt.Errorf("failed to validate pipeline schema: %w", err)
 	}
 
-	absPath, err := filepath.Abs(pipelineFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path for pipeline file %q: %w", pipelineFilePath, err)
-	}
-
-	pipeline, err := NewPlainPipelineFromBytes(absPath, bytes)
+	pipeline, err := NewPlainPipelineFromBytes(bytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pipeline file %w", err)
 	}
@@ -56,7 +50,7 @@ func NewPipelineFromFile(pipelineFilePath string, cfg config.Configuration) (*Pi
 	}
 	return pipeline, nil
 }
-func NewPlainPipelineFromBytes(filepath string, bytes []byte) (*Pipeline, error) {
+func NewPlainPipelineFromBytes(bytes []byte) (*Pipeline, error) {
 	rawPipeline := &struct {
 		Schema         string `yaml:"$schema,omitempty"`
 		ServiceGroup   string `yaml:"serviceGroup"`
@@ -64,7 +58,6 @@ func NewPlainPipelineFromBytes(filepath string, bytes []byte) (*Pipeline, error)
 		ResourceGroups []struct {
 			Name         string           `yaml:"name"`
 			Subscription string           `yaml:"subscription"`
-			AKSCluster   string           `yaml:"aksCluster,omitempty"`
 			Steps        []map[string]any `yaml:"steps"`
 		} `yaml:"resourceGroups"`
 	}{}
@@ -95,7 +88,6 @@ func NewPlainPipelineFromBytes(filepath string, bytes []byte) (*Pipeline, error)
 		pipeline.ResourceGroups[i] = rg
 		rg.Name = rawRg.Name
 		rg.Subscription = rawRg.Subscription
-		rg.AKSCluster = rawRg.AKSCluster
 		rg.Steps = make([]Step, len(rawRg.Steps))
 		for i, rawStep := range rawRg.Steps {
 			// preprocess variableRef step properties

--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -40,7 +40,7 @@ func NewPipelineFromFile(pipelineFilePath string, cfg config.Configuration) (*Pi
 		return nil, fmt.Errorf("failed to validate pipeline schema: %w", err)
 	}
 
-	pipeline, err := NewPlainPipelineFromBytes(bytes)
+	pipeline, err := NewPlainPipelineFromBytes("", bytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pipeline file %w", err)
 	}
@@ -50,15 +50,19 @@ func NewPipelineFromFile(pipelineFilePath string, cfg config.Configuration) (*Pi
 	}
 	return pipeline, nil
 }
-func NewPlainPipelineFromBytes(bytes []byte) (*Pipeline, error) {
+
+// Deprecated: first parameter can be removed
+func NewPlainPipelineFromBytes(_ string, bytes []byte) (*Pipeline, error) {
 	rawPipeline := &struct {
 		Schema         string `yaml:"$schema,omitempty"`
 		ServiceGroup   string `yaml:"serviceGroup"`
 		RolloutName    string `yaml:"rolloutName"`
 		ResourceGroups []struct {
-			Name         string           `yaml:"name"`
-			Subscription string           `yaml:"subscription"`
-			Steps        []map[string]any `yaml:"steps"`
+			Name         string `yaml:"name"`
+			Subscription string `yaml:"subscription"`
+			// Deprecated: AKSCluster to be removed
+			AKSCluster string           `yaml:"aksCluster,omitempty"`
+			Steps      []map[string]any `yaml:"steps"`
 		} `yaml:"resourceGroups"`
 	}{}
 	err := yaml.Unmarshal(bytes, rawPipeline)

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -507,6 +507,10 @@
                                 "action"
                             ]
                         }
+                    },
+                    "aksCluster": {
+                        "description": "Deprecated, to be removed", 
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -164,6 +164,9 @@
                                 "command": {
                                     "type": "string"
                                 },
+                                "aksCluster": {
+                                    "type": "string"
+                                },
                                 "variables": {
                                     "type": "array",
                                     "items": {
@@ -288,6 +291,9 @@
                                             "enum": ["Shell"]
                                         },
                                         "command": {
+                                            "type": "string"
+                                        },
+                                        "aksCluster": {
                                             "type": "string"
                                         },
                                         "variables": {
@@ -501,9 +507,6 @@
                                 "action"
                             ]
                         }
-                    },
-                    "aksCluster": {
-                        "type": "string"
                     }
                 },
                 "required": [

--- a/pkg/types/pipeline_test.go
+++ b/pkg/types/pipeline_test.go
@@ -14,7 +14,7 @@ func TestNewPlainPipelineFromBytes(t *testing.T) {
 	pipelineBytes, err := os.ReadFile("../../testdata/zz_fixture_TestNewPlainPipelineFromBytes.yaml")
 	assert.NoError(t, err)
 
-	p, err := NewPlainPipelineFromBytes(pipelineBytes)
+	p, err := NewPlainPipelineFromBytes("", pipelineBytes)
 	assert.NoError(t, err)
 
 	pipelineBytes, err = yaml.Marshal(p)

--- a/pkg/types/pipeline_test.go
+++ b/pkg/types/pipeline_test.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/ARO-Tools/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewPlainPipelineFromBytes(t *testing.T) {
+	pipelineBytes, err := os.ReadFile("../../testdata/zz_fixture_TestNewPlainPipelineFromBytes.yaml")
+	assert.NoError(t, err)
+
+	p, err := NewPlainPipelineFromBytes(pipelineBytes)
+	assert.NoError(t, err)
+
+	pipelineBytes, err = yaml.Marshal(p)
+	assert.NoError(t, err)
+
+	testutil.CompareWithFixture(t, pipelineBytes, testutil.WithExtension(".yaml"))
+
+}

--- a/pkg/types/pipeline_test.go
+++ b/pkg/types/pipeline_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/ARO-Tools/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+
+	"github.com/Azure/ARO-Tools/internal/testutil"
 )
 
 func TestNewPlainPipelineFromBytes(t *testing.T) {

--- a/pkg/types/resourcegroup.go
+++ b/pkg/types/resourcegroup.go
@@ -19,7 +19,6 @@ import "fmt"
 type ResourceGroup struct {
 	Name         string `yaml:"name"`
 	Subscription string `yaml:"subscription"`
-	AKSCluster   string `yaml:"aksCluster,omitempty"`
 	Steps        []Step `yaml:"steps"`
 }
 

--- a/pkg/types/resourcegroup.go
+++ b/pkg/types/resourcegroup.go
@@ -19,7 +19,9 @@ import "fmt"
 type ResourceGroup struct {
 	Name         string `yaml:"name"`
 	Subscription string `yaml:"subscription"`
-	Steps        []Step `yaml:"steps"`
+	// Deprecated: AKSCluster to be removed
+	AKSCluster string `yaml:"aksCluster,omitempty"`
+	Steps      []Step `yaml:"steps"`
 }
 
 func (rg *ResourceGroup) Validate() error {

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -17,10 +17,11 @@ package types
 import "fmt"
 
 type ShellStep struct {
-	StepMeta  `yaml:",inline"`
-	Command   string     `yaml:"command,omitempty"`
-	Variables []Variable `yaml:"variables,omitempty"`
-	DryRun    DryRun     `yaml:"dryRun,omitempty"`
+	StepMeta   `yaml:",inline"`
+	AKSCluster string     `yaml:"aksCluster,omitempty"`
+	Command    string     `yaml:"command,omitempty"`
+	Variables  []Variable `yaml:"variables,omitempty"`
+	DryRun     DryRun     `yaml:"dryRun,omitempty"`
 }
 
 func NewShellStep(name string, command string) *ShellStep {
@@ -35,6 +36,11 @@ func NewShellStep(name string, command string) *ShellStep {
 
 func (s *ShellStep) Description() string {
 	return fmt.Sprintf("Step %s\n  Kind: %s\n  Command: %s\n", s.Name, s.Action, s.Command)
+}
+
+func (s *ShellStep) WithAKSCluster(aksCluster string) *ShellStep {
+	s.AKSCluster = aksCluster
+	return s
 }
 
 func (s *ShellStep) WithDependsOn(dependsOn ...string) *ShellStep {

--- a/pkg/types/validation_test.go
+++ b/pkg/types/validation_test.go
@@ -210,7 +210,6 @@ func TestValidatePipelineSchema(t *testing.T) {
 					map[string]interface{}{
 						"name":         "rg",
 						"subscription": "sub",
-						"aksCluster":   "aks",
 						"steps": []interface{}{
 							map[string]interface{}{
 								"name":    "step",

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -4,11 +4,11 @@ rolloutName: Test Rollout
 resourceGroups:
 - name: '{{ .regionRG  }}'
   subscription: '{{ .serviceClusterSubscription  }}'
-  aksCluster: '{{ .aksName  }}'
   steps:
   - name: deploy
     action: Shell
     command: make deploy
+    aksCluster: '{{ .aksName  }}'
     variables:
     - name: MAESTRO_IMAGE
       configRef: maestro_image

--- a/testdata/zz_fixture_TestNewPlainPipelineFromBytes.yaml
+++ b/testdata/zz_fixture_TestNewPlainPipelineFromBytes.yaml
@@ -1,13 +1,13 @@
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
 resourceGroups:
-    - name: hcp-underlay-$(regionShortName)
-      subscription: hcp-$location()
+    - name: '{{ .regionRG  }}'
+      subscription: '{{ .serviceClusterSubscription  }}'
       steps:
         - name: deploy
           action: Shell
+          aksCluster: '{{ .aksName  }}'
           command: make deploy
-          aksCluster: test
           variables:
             - name: MAESTRO_IMAGE
               configRef: maestro_image
@@ -18,10 +18,13 @@ resourceGroups:
             variables:
                 - name: DRY_RUN
                   value: A very dry one
+        - name: optionalStep
+          action: Shell
+          command: make optional
         - name: svc
           action: ARM
           template: templates/svc-cluster.bicep
-          parameters: ev2-precompiled-test.bicepparam
+          parameters: test.bicepparam
           deploymentLevel: ResourceGroup
         - name: cxChildZone
           action: DelegateChildZone


### PR DESCRIPTION
Move attribute under Shellstep, since we do not need it for every resourcegroup. Added a test for pipeline creation method