### PR TITLE
pkg/types: add a image mirror step

### DIFF
--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+
+	_ "embed"
+)
+
+//go:embed on-demand.sh
+var OnDemandSyncScript []byte
+
+// ImageMirrorStep is a handy wrapper over a ShellStep that allows many users of this tooling to mirror images in the
+// same way without having to worry about the shell script itself.
+type ImageMirrorStep struct {
+	StepMeta `json:",inline"`
+
+	TargetACR          Variable `json:"targetACR,omitempty"`
+	SourceRegistry     Variable `json:"sourceRegistry,omitempty"`
+	Repository         Variable `json:"repository,omitempty"`
+	Digest             Variable `json:"digest,omitempty"`
+	PullSecretKeyVault Variable `json:"pullSecretKeyVault,omitempty"`
+	PullSecretName     Variable `json:"pullSecretName,omitempty"`
+	ShellIdentity      Variable `json:"shellIdentity,omitempty"`
+}
+
+func (s *ImageMirrorStep) Description() string {
+	return fmt.Sprintf("Step %s\n  Kind: %s\n  From %v:%v@%v to %v\n", s.Name, s.Action, s.SourceRegistry, s.Repository, s.Digest, s.TargetACR)
+}
+
+// ResolveImageMirrorStep resolves an image mirror step to a shell step. It's up to the user to write the contents of
+// the OnDemandSyncScript to disk somewhere and pass the file name in as a parameter here, as we likely don't want to
+// inline 100+ lines of shell into a `bash -C "<contents>"` call and hope all the string interpolations work.
+func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (Step, error) {
+	return &ShellStep{
+		StepMeta: StepMeta{
+			Name:   "image-mirror",
+			Action: "Shell",
+		},
+		Command: scriptFile,
+		Variables: []Variable{
+			namedVariable("TARGET_ACR", input.TargetACR),
+			namedVariable("SOURCE_REGISTRY", input.SourceRegistry),
+			namedVariable("REPOSITORY", input.Repository),
+			namedVariable("DIGEST", input.Digest),
+			namedVariable("PULL_SECRET_KV", input.PullSecretKeyVault),
+			namedVariable("PULL_SECRET", input.PullSecretName),
+		},
+		DryRun: DryRun{
+			Variables: []Variable{{
+				Name:  "DRY_RUN",
+				Value: "true",
+			}},
+		},
+		ShellIdentity: input.ShellIdentity,
+	}, nil
+}
+
+func namedVariable(name string, variable Variable) Variable {
+	return Variable{
+		Name:      name,
+		Value:     variable.Value,
+		ConfigRef: variable.ConfigRef,
+		Input:     variable.Input,
+	}
+}
+
+// NewImageMirrorStep creates a new image mirror step.
+func NewImageMirrorStep() *ImageMirrorStep {
+	return &ImageMirrorStep{
+		StepMeta: StepMeta{
+			Name:   "image-mirror",
+			Action: "ImageMirror",
+		},
+	}
+}
+
+// WithTargetACR fluent method that sets TargetACR.
+func (s *ImageMirrorStep) WithTargetACR(targetACR Variable) *ImageMirrorStep {
+	s.TargetACR = targetACR
+	return s
+}
+
+// WithSourceRegistry fluent method that sets SourceRegistry.
+func (s *ImageMirrorStep) WithSourceRegistry(sourceRegistry Variable) *ImageMirrorStep {
+	s.SourceRegistry = sourceRegistry
+	return s
+}
+
+// WithRepository fluent method that sets Repository.
+func (s *ImageMirrorStep) WithRepository(repository Variable) *ImageMirrorStep {
+	s.Repository = repository
+	return s
+}
+
+// WithDigest fluent method that sets Digest.
+func (s *ImageMirrorStep) WithDigest(digest Variable) *ImageMirrorStep {
+	s.Digest = digest
+	return s
+}
+
+// WithPullSecretKeyVault fluent method that sets PullSecretKeyVault.
+func (s *ImageMirrorStep) WithPullSecretKeyVault(pullSecretKeyVault Variable) *ImageMirrorStep {
+	s.PullSecretKeyVault = pullSecretKeyVault
+	return s
+}
+
+// WithPullSecretName fluent method that sets PullSecretName.
+func (s *ImageMirrorStep) WithPullSecretName(pullSecretName Variable) *ImageMirrorStep {
+	s.PullSecretName = pullSecretName
+	return s
+}
+
+// WithShellIdentity fluent method that sets ShellIdentity.
+func (s *ImageMirrorStep) WithShellIdentity(shellIdentity Variable) *ImageMirrorStep {
+	s.ShellIdentity = shellIdentity
+	return s
+}

--- a/pkg/types/on-demand.sh
+++ b/pkg/types/on-demand.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# only run within EV2 and within GH actions for now
+if [[ -z "${EV2:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+  exit 0
+fi
+
+if [ -n "${GITHUB_ACTIONS:-}" ] && [ -z "${DIGEST:-}" ]; then
+  echo "Running in GitHub Actions but no digest provided. We assume the image is somehow else provided."
+  exit 0
+fi
+
+# validate
+REQUIRED_VARS=("PULL_SECRET_KV" "PULL_SECRET" "TARGET_ACR" "SOURCE_REGISTRY" "REPOSITORY" "DIGEST")
+for VAR in "${REQUIRED_VARS[@]}"; do
+    if [ -z "${!VAR}" ]; then
+        echo "Error: Environment variable $VAR is not set."
+        exit 1
+    fi
+done
+
+# create temporary FS structure
+TMP_DIR="$(mktemp -d)"
+CONTAINERS_DIR="${TMP_DIR}/containers"
+AUTH_JSON="${CONTAINERS_DIR}/auth.json"
+ORAS_CACHE="${TMP_DIR}/oras-cache"
+mkdir -p "${CONTAINERS_DIR}"
+mkdir -p "${ORAS_CACHE}"
+trap 'rm -rf ${TMP_DIR}' EXIT
+
+# get pull secret for source registry
+echo "Fetch pull secret for source registry ${SOURCE_REGISTRY} from ${PULL_SECRET_KV} KV."
+az keyvault secret download --vault-name "${PULL_SECRET_KV}" --name "${PULL_SECRET}" -e base64 --file "${AUTH_JSON}"
+
+# ACR login to target registry
+echo "Logging into target ACR ${TARGET_ACR}."
+if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors 2>&1 )"; then
+  RESPONSE="${output}"
+else
+  echo "Failed to log in to ACR ${TARGET_ACR}: ${output}"
+  exit 1
+fi
+TARGET_ACR_LOGIN_SERVER="$(jq --raw-output .loginServer <<<"${RESPONSE}" )"
+oras login --registry-config "${AUTH_JSON}" \
+           --username 00000000-0000-0000-0000-000000000000 \
+           --password-stdin \
+           "${TARGET_ACR_LOGIN_SERVER}" <<<"$( jq --raw-output .accessToken <<<"${RESPONSE}" )"
+
+# at this point we have an auth config that can read from the source registry and
+# write to the target registry.
+
+# Check for DRY_RUN
+if [ "${DRY_RUN:-false}" == "true" ]; then
+    echo "DRY_RUN is enabled. Exiting without making changes."
+    exit 0
+fi
+
+# mirror image
+SRC_IMAGE="${SOURCE_REGISTRY}/${REPOSITORY}@${DIGEST}"
+DIGEST_NO_PREFIX=${DIGEST#sha256:}
+# we use the digest as a tag so the image can be inspected easily in the ACR
+# this does not affect the fact that the image is stored by immutable digest in the ACR
+# it is crucial though, that the tagged image is not used in favor of the @sha256:digest one
+# as the tag is NOT guaranteed to be immutable
+TARGET_IMAGE="${TARGET_ACR_LOGIN_SERVER}/${REPOSITORY}:${DIGEST_NO_PREFIX}"
+echo "Mirroring image ${SRC_IMAGE} to ${TARGET_IMAGE}."
+echo "The image will still be available under it's original digest ${DIGEST} in the target registry."
+oras cp "${SRC_IMAGE}" "${TARGET_IMAGE}" --from-registry-config "${AUTH_JSON}" --to-registry-config "${AUTH_JSON}"

--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -132,6 +132,8 @@ func NewPlainPipelineFromBytes(_ string, bytes []byte) (*Pipeline, error) {
 				rg.Steps[i] = &CreateCertificateStep{}
 			case "ResourceProviderRegistration":
 				rg.Steps[i] = &ResourceProviderRegistrationStep{}
+			case "ImageMirror":
+				rg.Steps[i] = &ImageMirrorStep{}
 			case "RPLogsAccount", "ClusterLogsAccount":
 				rg.Steps[i] = &LogsStep{}
 			default:

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -415,6 +415,53 @@
                                         "configVersion",
                                         "events"
                                     ]
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "action": {
+                                            "const": "ImageMirror"
+                                        },
+                                        "targetACR" : {
+                                            "$ref": "#/definitions/variableRef"
+                                        },
+                                        "sourceRegistry" : {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "repository" :  {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "digest" : {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "pullSecretKeyVault" :  {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "pullSecretName" : {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "shellIdentity" :  {
+                                            "$ref":  "#/definitions/variableRef"
+                                        },
+                                        "dependsOn": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "targetACR",
+                                        "sourceRegistry",
+                                        "repository",
+                                        "digest",
+                                        "pullSecretKeyVault",
+                                        "pullSecretName",
+                                        "shellIdentity"
+                                    ]
                                 }
                             ],
                             "required": [

--- a/pkg/types/variables.go
+++ b/pkg/types/variables.go
@@ -14,6 +14,8 @@
 
 package types
 
+import "fmt"
+
 // Variable
 // Use this to pass in values to pipeline steps. Values can come from various sources:
 //   - Value: Use the value field to "hardcode" a value.
@@ -24,6 +26,19 @@ type Variable struct {
 	Value     any    `json:"value,omitempty"`
 	ConfigRef string `json:"configRef,omitempty"`
 	Input     *Input `json:"input,omitempty"`
+}
+
+func (v *Variable) String() string {
+	if v.Value != nil {
+		return fmt.Sprintf("%v", v.Value)
+	}
+	if v.ConfigRef != "" {
+		return fmt.Sprintf("{{ %v }}", v.ConfigRef)
+	}
+	if v.Input != nil {
+		return fmt.Sprintf("{{ inputs %s.%v }{", v.Input.Name, v.Input.Step)
+	}
+	return "unknown"
 }
 
 // Input

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -105,3 +105,19 @@ resourceGroups:
       value: version
     events:
       akskubesystem: kubesystem
+  - name: image-mirror
+    action: ImageMirror
+    targetACR:
+      value: targetACR
+    sourceRegistry:
+      value: sourceRegistry
+    repository:
+      value: repository
+    digest:
+      value: digest
+    pullSecretKeyVault:
+      value: pullSecretKeyVault
+    pullSecretName:
+      value: pullSecretName
+    shellIdentity:
+      value: shellIdentity

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -127,6 +127,29 @@ resourceGroups:
     subscriptionId:
       name: subscriptionId
       value: sub
+  - action: ImageMirror
+    digest:
+      name: digest
+      value: digest
+    name: image-mirror
+    pullSecretKeyVault:
+      name: pullSecretKeyVault
+      value: pullSecretKeyVault
+    pullSecretName:
+      name: pullSecretName
+      value: pullSecretName
+    repository:
+      name: repository
+      value: repository
+    shellIdentity:
+      name: shellIdentity
+      value: shellIdentity
+    sourceRegistry:
+      name: sourceRegistry
+      value: sourceRegistry
+    targetACR:
+      name: targetACR
+      value: targetACR
   subscription: hcp-uksouth
 rolloutName: Test Rollout
 serviceGroup: Microsoft.Azure.ARO.Test


### PR DESCRIPTION
The new image mirror step simply resolves to a shell step under the covers, but we want to allow it to be a first-class concept to make it easier for many different repositories to re-use the script.