### PR TITLE
pkg/types: return shell step from image mirror resolution

### DIFF
--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -44,7 +44,7 @@ func (s *ImageMirrorStep) Description() string {
 // ResolveImageMirrorStep resolves an image mirror step to a shell step. It's up to the user to write the contents of
 // the OnDemandSyncScript to disk somewhere and pass the file name in as a parameter here, as we likely don't want to
 // inline 100+ lines of shell into a `bash -C "<contents>"` call and hope all the string interpolations work.
-func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (Step, error) {
+func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (*ShellStep, error) {
 	return &ShellStep{
 		StepMeta: StepMeta{
 			Name:   "image-mirror",


### PR DESCRIPTION
This is the more useful type that downstream users need anyway.