### PR TITLE
ev2config: expose available clouds and regions

### DIFF
--- a/pkg/config/ev2config/config.go
+++ b/pkg/config/ev2config/config.go
@@ -13,6 +13,21 @@ import (
 //go:embed config.yaml
 var rawConfig []byte
 
+func AllContexts() (map[string][]string, error) {
+	ev2Config := config{}
+	if err := yaml.Unmarshal(rawConfig, &ev2Config); err != nil {
+		return nil, fmt.Errorf("failed to parse embedded Ev2 config: %w", err)
+	}
+	contexts := map[string][]string{}
+	for cloud := range ev2Config.Clouds {
+		contexts[cloud] = []string{}
+		for region := range ev2Config.Clouds[cloud].Regions {
+			contexts[cloud] = append(contexts[cloud], region)
+		}
+	}
+	return contexts, nil
+}
+
 func ResolveConfig(cloud, region string) (coreconfig.Configuration, error) {
 	ev2Config := config{}
 	if err := yaml.Unmarshal(rawConfig, &ev2Config); err != nil {


### PR DESCRIPTION
Similarly to how we do for service configuration, expose all the clouds and regions we have registered so consumers can loop over them.