### PR TITLE
pkg/types: use Values, not Variables, where possible

### DIFF
--- a/pkg/types/arm.go
+++ b/pkg/types/arm.go
@@ -23,13 +23,13 @@ import (
 // This struct supports fluent interface With... methods.
 type ARMStep struct {
 	StepMeta        `json:",inline"`
-	Command         string     `json:"command,omitempty"`
-	Variables       []Variable `json:"variables,omitempty"`
-	Template        string     `json:"template,omitempty"`
-	Parameters      string     `json:"parameters,omitempty"`
-	DeploymentLevel string     `json:"deploymentLevel,omitempty"`
-	OutputOnly      bool       `json:"outputOnly,omitempty"`
-	DeploymentMode  string     `json:"deploymentMode,omitempty"`
+	Command         string  `json:"command,omitempty"`
+	Variables       []Value `json:"variables,omitempty"`
+	Template        string  `json:"template,omitempty"`
+	Parameters      string  `json:"parameters,omitempty"`
+	DeploymentLevel string  `json:"deploymentLevel,omitempty"`
+	OutputOnly      bool    `json:"outputOnly,omitempty"`
+	DeploymentMode  string  `json:"deploymentMode,omitempty"`
 }
 
 // NewARMStep creates a new ARM deployment step with the given parameters.
@@ -60,9 +60,9 @@ func (s *ARMStep) WithDependsOn(dependsOn ...string) *ARMStep {
 	return s
 }
 
-// WithVariables fluent method that sets Variables
-func (s *ARMStep) WithVariables(variables ...Variable) *ARMStep {
-	s.Variables = variables
+// WithValues fluent method that sets Values
+func (s *ARMStep) WithValues(values ...Value) *ARMStep {
+	s.Variables = values
 	return s
 }
 

--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -57,8 +57,8 @@ type DryRun struct {
 
 type DelegateChildZoneStep struct {
 	StepMeta   `json:",inline"`
-	ParentZone Variable `json:"parentZone,omitempty"`
-	ChildZone  Variable `json:"childZone,omitempty"`
+	ParentZone Value `json:"parentZone,omitempty"`
+	ChildZone  Value `json:"childZone,omitempty"`
 }
 
 func (s *DelegateChildZoneStep) Description() string {
@@ -67,8 +67,8 @@ func (s *DelegateChildZoneStep) Description() string {
 
 type SetCertificateIssuerStep struct {
 	StepMeta     `json:",inline"`
-	VaultBaseUrl Variable `json:"vaultBaseUrl,omitempty"`
-	Issuer       Variable `json:"issuer,omitempty"`
+	VaultBaseUrl Value `json:"vaultBaseUrl,omitempty"`
+	Issuer       Value `json:"issuer,omitempty"`
 }
 
 func (s *SetCertificateIssuerStep) Description() string {
@@ -77,11 +77,11 @@ func (s *SetCertificateIssuerStep) Description() string {
 
 type CreateCertificateStep struct {
 	StepMeta        `json:",inline"`
-	VaultBaseUrl    Variable `json:"vaultBaseUrl,omitempty"`
-	CertificateName Variable `json:"certificateName,omitempty"`
-	ContentType     Variable `json:"contentType,omitempty"`
-	SAN             Variable `json:"san,omitempty"`
-	Issuer          Variable `json:"issuer,omitempty"`
+	VaultBaseUrl    Value `json:"vaultBaseUrl,omitempty"`
+	CertificateName Value `json:"certificateName,omitempty"`
+	ContentType     Value `json:"contentType,omitempty"`
+	SAN             Value `json:"san,omitempty"`
+	Issuer          Value `json:"issuer,omitempty"`
 }
 
 func (s *CreateCertificateStep) Description() string {
@@ -90,7 +90,7 @@ func (s *CreateCertificateStep) Description() string {
 
 type ResourceProviderRegistrationStep struct {
 	StepMeta                   `json:",inline"`
-	ResourceProviderNamespaces Variable `json:"resourceProviderNamespaces,omitempty"`
+	ResourceProviderNamespaces Value `json:"resourceProviderNamespaces,omitempty"`
 }
 
 func (s *ResourceProviderRegistrationStep) Description() string {
@@ -99,11 +99,11 @@ func (s *ResourceProviderRegistrationStep) Description() string {
 
 type LogsStep struct {
 	StepMeta        `json:",inline"`
-	SubscriptionId  Variable   `json:"subscriptionId,omitempty"`
-	Namespace       Variable   `json:"namespace,omitempty"`
-	CertSAN         Variable   `json:"certsan,omitempty"`
-	CertDescription Variable   `json:"certdescription,omitempty"`
-	ConfigVersion   Variable   `json:"configVersion,omitempty"`
+	SubscriptionId  Value      `json:"subscriptionId,omitempty"`
+	Namespace       Value      `json:"namespace,omitempty"`
+	CertSAN         Value      `json:"certsan,omitempty"`
+	CertDescription Value      `json:"certdescription,omitempty"`
+	ConfigVersion   Value      `json:"configVersion,omitempty"`
 	Events          LogsEvents `json:"events,omitempty"`
 }
 

--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -28,13 +28,13 @@ var OnDemandSyncScript []byte
 type ImageMirrorStep struct {
 	StepMeta `json:",inline"`
 
-	TargetACR          Variable `json:"targetACR,omitempty"`
-	SourceRegistry     Variable `json:"sourceRegistry,omitempty"`
-	Repository         Variable `json:"repository,omitempty"`
-	Digest             Variable `json:"digest,omitempty"`
-	PullSecretKeyVault Variable `json:"pullSecretKeyVault,omitempty"`
-	PullSecretName     Variable `json:"pullSecretName,omitempty"`
-	ShellIdentity      Variable `json:"shellIdentity,omitempty"`
+	TargetACR          Value `json:"targetACR,omitempty"`
+	SourceRegistry     Value `json:"sourceRegistry,omitempty"`
+	Repository         Value `json:"repository,omitempty"`
+	Digest             Value `json:"digest,omitempty"`
+	PullSecretKeyVault Value `json:"pullSecretKeyVault,omitempty"`
+	PullSecretName     Value `json:"pullSecretName,omitempty"`
+	ShellIdentity      Value `json:"shellIdentity,omitempty"`
 }
 
 func (s *ImageMirrorStep) Description() string {
@@ -61,20 +61,24 @@ func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (*ShellSte
 		},
 		DryRun: DryRun{
 			Variables: []Variable{{
-				Name:  "DRY_RUN",
-				Value: "true",
+				Name: "DRY_RUN",
+				Value: Value{
+					Value: "true",
+				},
 			}},
 		},
 		ShellIdentity: input.ShellIdentity,
 	}, nil
 }
 
-func namedVariable(name string, variable Variable) Variable {
+func namedVariable(name string, value Value) Variable {
 	return Variable{
-		Name:      name,
-		Value:     variable.Value,
-		ConfigRef: variable.ConfigRef,
-		Input:     variable.Input,
+		Name: name,
+		Value: Value{
+			Value:     value.Value,
+			ConfigRef: value.ConfigRef,
+			Input:     value.Input,
+		},
 	}
 }
 
@@ -89,43 +93,43 @@ func NewImageMirrorStep() *ImageMirrorStep {
 }
 
 // WithTargetACR fluent method that sets TargetACR.
-func (s *ImageMirrorStep) WithTargetACR(targetACR Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithTargetACR(targetACR Value) *ImageMirrorStep {
 	s.TargetACR = targetACR
 	return s
 }
 
 // WithSourceRegistry fluent method that sets SourceRegistry.
-func (s *ImageMirrorStep) WithSourceRegistry(sourceRegistry Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithSourceRegistry(sourceRegistry Value) *ImageMirrorStep {
 	s.SourceRegistry = sourceRegistry
 	return s
 }
 
 // WithRepository fluent method that sets Repository.
-func (s *ImageMirrorStep) WithRepository(repository Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithRepository(repository Value) *ImageMirrorStep {
 	s.Repository = repository
 	return s
 }
 
 // WithDigest fluent method that sets Digest.
-func (s *ImageMirrorStep) WithDigest(digest Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithDigest(digest Value) *ImageMirrorStep {
 	s.Digest = digest
 	return s
 }
 
 // WithPullSecretKeyVault fluent method that sets PullSecretKeyVault.
-func (s *ImageMirrorStep) WithPullSecretKeyVault(pullSecretKeyVault Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithPullSecretKeyVault(pullSecretKeyVault Value) *ImageMirrorStep {
 	s.PullSecretKeyVault = pullSecretKeyVault
 	return s
 }
 
 // WithPullSecretName fluent method that sets PullSecretName.
-func (s *ImageMirrorStep) WithPullSecretName(pullSecretName Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithPullSecretName(pullSecretName Value) *ImageMirrorStep {
 	s.PullSecretName = pullSecretName
 	return s
 }
 
 // WithShellIdentity fluent method that sets ShellIdentity.
-func (s *ImageMirrorStep) WithShellIdentity(shellIdentity Variable) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithShellIdentity(shellIdentity Value) *ImageMirrorStep {
 	s.ShellIdentity = shellIdentity
 	return s
 }

--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -81,16 +81,6 @@ func NewPlainPipelineFromBytes(_ string, bytes []byte) (*Pipeline, error) {
 		return nil, fmt.Errorf("failed to unmarshal pipeline: %w", err)
 	}
 
-	// find step properties that are variableRefs
-	pipelineSchema, _, err := getSchemaForRef(rawPipeline.Schema)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get schema for pipeline: %w", err)
-	}
-	variableRefStepProperties, err := getVariableRefStepProperties(pipelineSchema)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get variableRef step properties: %w", err)
-	}
-
 	pipeline := &Pipeline{
 		Schema:         rawPipeline.Schema,
 		ServiceGroup:   rawPipeline.ServiceGroup,
@@ -105,14 +95,6 @@ func NewPlainPipelineFromBytes(_ string, bytes []byte) (*Pipeline, error) {
 		rg.Subscription = rawRg.Subscription
 		rg.Steps = make([]Step, len(rawRg.Steps))
 		for i, rawStep := range rawRg.Steps {
-			// preprocess variableRef step properties
-			for propName := range rawStep {
-				if _, ok := variableRefStepProperties[propName]; ok {
-					variableRef := rawStep[propName].(map[string]any)
-					variableRef["name"] = propName
-				}
-			}
-
 			// unmarshal the map into a StepMeta
 			stepMeta := &StepMeta{}
 			err := mapToStruct(rawStep, stepMeta)

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -16,13 +16,10 @@
                 }
             ]
         },
-        "variableRef": {
+        "value": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "name": {
-                    "type": "string"
-                },
                 "input": {
                     "type": "object",
                     "additionalProperties": false,
@@ -219,7 +216,7 @@
                                             "type": "string"
                                         },
                                         "shellIdentity": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -257,10 +254,10 @@
                                             "const": "DelegateChildZone"
                                         },
                                         "parentZone": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "childZone": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -284,10 +281,10 @@
                                             "const": "SetCertificateIssuer"
                                         },
                                         "vaultBaseUrl": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "issuer": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -311,19 +308,19 @@
                                             "const": "CreateCertificate"
                                         },
                                         "vaultBaseUrl": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "certificateName": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "contentType": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "san": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "issuer": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -350,7 +347,7 @@
                                             "const": "ResourceProviderRegistration"
                                         },
                                         "resourceProviderNamespaces": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -374,19 +371,19 @@
                                             "enum": ["RPLogsAccount", "ClusterLogsAccount"]
                                         },
                                         "subscriptionId": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "namespace": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "certsan": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "certdescription": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "configVersion": {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "events": {
                                             "type": "object",
@@ -426,25 +423,25 @@
                                             "const": "ImageMirror"
                                         },
                                         "targetACR" : {
-                                            "$ref": "#/definitions/variableRef"
+                                            "$ref": "#/definitions/value"
                                         },
                                         "sourceRegistry" : {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "repository" :  {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "digest" : {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "pullSecretKeyVault" :  {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "pullSecretName" : {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "shellIdentity" :  {
-                                            "$ref":  "#/definitions/variableRef"
+                                            "$ref":  "#/definitions/value"
                                         },
                                         "dependsOn": {
                                             "type": "array",

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -26,7 +26,7 @@ type ShellStep struct {
 	DryRun        DryRun      `json:"dryRun,omitempty"`
 	References    []Reference `json:"references,omitempty"`
 	SubnetId      string      `json:"subnetId,omitempty"`
-	ShellIdentity Variable    `json:"shellIdentity,omitempty"`
+	ShellIdentity Value    `json:"shellIdentity,omitempty"`
 }
 
 // Reference represents a configurable reference

--- a/pkg/types/util.go
+++ b/pkg/types/util.go
@@ -17,7 +17,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
@@ -59,23 +58,6 @@ func getSchemaForRef(schemaRef string) (*jsonschema.Schema, string, error) {
 	default:
 		return nil, "", fmt.Errorf("unsupported schema reference: %s", schemaRef)
 	}
-}
-
-func getVariableRefStepProperties(pipelineSchema *jsonschema.Schema) (map[string]*jsonschema.Schema, error) {
-	stepProperties := map[string]*jsonschema.Schema{}
-	for _, stepDef := range pipelineSchema.Properties["resourceGroups"].Items.(*jsonschema.Schema).Properties["steps"].Items.(*jsonschema.Schema).OneOf {
-		for name, value := range stepDef.Properties {
-			stepProperties[name] = value
-		}
-	}
-
-	variableRefProperties := make(map[string]*jsonschema.Schema)
-	for propName, propValue := range stepProperties {
-		if propValue.Ref != nil && strings.HasSuffix(propValue.Ref.Location, "#/definitions/variableRef") {
-			variableRefProperties[propName] = propValue
-		}
-	}
-	return variableRefProperties, nil
 }
 
 func ValidatePipelineSchema(pipelineContent []byte) error {

--- a/pkg/types/variables.go
+++ b/pkg/types/variables.go
@@ -17,18 +17,28 @@ package types
 import "fmt"
 
 // Variable
+// Use this to pass in values to shell steps. Pairs a value with the environment variable name.
+type Variable struct {
+	Name  string `json:"name,omitempty"`
+	Value `json:",inline"`
+}
+
+func (v *Variable) String() string {
+	return fmt.Sprintf("$%s=%s", v.Name, v.Value.String())
+}
+
+// Value
 // Use this to pass in values to pipeline steps. Values can come from various sources:
 //   - Value: Use the value field to "hardcode" a value.
 //   - ConfigRef: Use this to reference an entry in a config.Configuration.
 //   - Input: Use this to specify an output chaining input.
-type Variable struct {
-	Name      string `json:"name,omitempty"`
+type Value struct {
 	Value     any    `json:"value,omitempty"`
 	ConfigRef string `json:"configRef,omitempty"`
 	Input     *Input `json:"input,omitempty"`
 }
 
-func (v *Variable) String() string {
+func (v *Value) String() string {
 	if v.Value != nil {
 		return fmt.Sprintf("%v", v.Value)
 	}
@@ -36,7 +46,7 @@ func (v *Variable) String() string {
 		return fmt.Sprintf("{{ %v }}", v.ConfigRef)
 	}
 	if v.Input != nil {
-		return fmt.Sprintf("{{ inputs %s.%v }{", v.Input.Name, v.Input.Step)
+		return fmt.Sprintf("{{ inputs %s.%v }}", v.Input.Name, v.Input.Step)
 	}
 	return "unknown"
 }

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -9,7 +9,6 @@ resourceGroups:
     name: deploy
     shellIdentity:
       configRef: aroDevopsMsiId
-      name: shellIdentity
     variables:
     - configRef: maestro_image
       name: MAESTRO_IMAGE
@@ -26,7 +25,6 @@ resourceGroups:
     name: dry-run
     shellIdentity:
       configRef: aroDevopsMsiId
-      name: shellIdentity
   - action: ARM
     deploymentLevel: ResourceGroup
     name: svc
@@ -35,120 +33,91 @@ resourceGroups:
   - action: DelegateChildZone
     childZone:
       configRef: childZone
-      name: childZone
     dependsOn:
     - deploy
     name: cxChildZone
     parentZone:
       configRef: parentZone
-      name: parentZone
   - action: SetCertificateIssuer
     dependsOn:
     - deploy
     issuer:
       configRef: provider
-      name: issuer
     name: issuerTest
     vaultBaseUrl:
       configRef: vaultBaseUrl
-      name: vaultBaseUrl
   - action: SetCertificateIssuer
     dependsOn:
     - deploy
     issuer:
-      name: issuer
       value: provider
     name: issuerTestOutputChaining
     vaultBaseUrl:
       input:
         name: kvUrl
         step: deploy
-      name: vaultBaseUrl
   - action: CreateCertificate
     certificateName:
-      name: certificateName
       value: hcp-mdsd
     contentType:
-      name: contentType
       value: x-pem-file
     issuer:
-      name: issuer
       value: OneCertV2-PrivateCA
     name: cert
     san:
-      name: san
       value: hcp-mdsd.geneva.keyvault.aro-int.azure.com
     vaultBaseUrl:
-      name: vaultBaseUrl
       value: https://arohcp-svc-ln.vault.azure.net
   - action: ResourceProviderRegistration
     name: rpRegistration
     resourceProviderNamespaces:
-      name: resourceProviderNamespaces
       value:
       - Microsoft.Storage
       - Microsoft.EventHub
       - Microsoft.Insights
   - action: RPLogsAccount
     certdescription:
-      name: certdescription
       value: HCP Service Cluster
     certsan:
-      name: certsan
       value: san
     configVersion:
-      name: configVersion
       value: version
     events:
       akskubesystem: kubesystem
     name: rpAccount
     namespace:
-      name: namespace
       value: ns
     subscriptionId:
-      name: subscriptionId
       value: sub
   - action: ClusterLogsAccount
     certdescription:
-      name: certdescription
       value: HCP Management Cluster
     certsan:
-      name: certsan
       value: san
     configVersion:
-      name: configVersion
       value: version
     events:
       akskubesystem: kubesystem
     name: clusterAccount
     namespace:
-      name: namespace
       value: ns
     subscriptionId:
-      name: subscriptionId
       value: sub
   - action: ImageMirror
     digest:
-      name: digest
       value: digest
     name: image-mirror
     pullSecretKeyVault:
-      name: pullSecretKeyVault
       value: pullSecretKeyVault
     pullSecretName:
-      name: pullSecretName
       value: pullSecretName
     repository:
-      name: repository
       value: repository
     shellIdentity:
-      name: shellIdentity
       value: shellIdentity
     sourceRegistry:
-      name: sourceRegistry
       value: sourceRegistry
     targetACR:
-      name: targetACR
       value: targetACR
   subscription: hcp-uksouth
 rolloutName: Test Rollout


### PR DESCRIPTION
In most of the cases where we were using Variables, we did not want or need a name - we were just allowing the user to provide a value, config reference, or input chain. This commit separates out that concern and uses it where we can. We also remove the JSONSchema-based name field defaulting, as we no longer need that.