### PR TITLE
pkg/types: revert ARM variable change

### DIFF
--- a/pkg/types/arm.go
+++ b/pkg/types/arm.go
@@ -23,13 +23,13 @@ import (
 // This struct supports fluent interface With... methods.
 type ARMStep struct {
 	StepMeta        `json:",inline"`
-	Command         string  `json:"command,omitempty"`
-	Variables       []Value `json:"variables,omitempty"`
-	Template        string  `json:"template,omitempty"`
-	Parameters      string  `json:"parameters,omitempty"`
-	DeploymentLevel string  `json:"deploymentLevel,omitempty"`
-	OutputOnly      bool    `json:"outputOnly,omitempty"`
-	DeploymentMode  string  `json:"deploymentMode,omitempty"`
+	Command         string     `json:"command,omitempty"`
+	Variables       []Variable `json:"variables,omitempty"`
+	Template        string     `json:"template,omitempty"`
+	Parameters      string     `json:"parameters,omitempty"`
+	DeploymentLevel string     `json:"deploymentLevel,omitempty"`
+	OutputOnly      bool       `json:"outputOnly,omitempty"`
+	DeploymentMode  string     `json:"deploymentMode,omitempty"`
 }
 
 // NewARMStep creates a new ARM deployment step with the given parameters.
@@ -60,9 +60,9 @@ func (s *ARMStep) WithDependsOn(dependsOn ...string) *ARMStep {
 	return s
 }
 
-// WithValues fluent method that sets Values
-func (s *ARMStep) WithValues(values ...Value) *ARMStep {
-	s.Variables = values
+// WithVariables fluent method that sets Variables
+func (s *ARMStep) WithVariables(variables ...Variable) *ARMStep {
+	s.Variables = variables
 	return s
 }
 

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -32,6 +32,11 @@ resourceGroups:
     template: templates/svc-cluster.bicep
     parameters: test.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+      - name: MAESTRO_IMAGE
+        input:
+          step: deploy
+          name: whatever
   - name: cxChildZone
     action: DelegateChildZone
     parentZone:

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -30,6 +30,11 @@ resourceGroups:
     name: svc
     parameters: test.bicepparam
     template: templates/svc-cluster.bicep
+    variables:
+    - input:
+        name: whatever
+        step: deploy
+      name: MAESTRO_IMAGE
   - action: DelegateChildZone
     childZone:
       configRef: childZone


### PR DESCRIPTION
ARM Variables (really, these are just input chains) do need a name. Added test data to the pipeline.yaml to catch this.