### PR TITLE
pkg/config: use dummy template data to load config

### DIFF
--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-Tools/pkg/config/types"
 )
 
 func TestValidateSchema(t *testing.T) {
@@ -27,9 +29,9 @@ func TestValidateSchema(t *testing.T) {
 }
 
 func TestConvertToInterface(t *testing.T) {
-	vars := Configuration{
+	vars := types.Configuration{
 		"key1": "value1",
-		"key2": Configuration{
+		"key2": types.Configuration{
 			"key3": "value3",
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/ARO-Tools/internal/testutil"
 	"github.com/Azure/ARO-Tools/pkg/config"
 	"github.com/Azure/ARO-Tools/pkg/config/ev2config"
+	"github.com/Azure/ARO-Tools/pkg/config/types"
 )
 
 func TestConfigProvider(t *testing.T) {
@@ -59,18 +60,18 @@ func TestInterfaceToConfiguration(t *testing.T) {
 		name                   string
 		i                      interface{}
 		ok                     bool
-		expecetedConfiguration config.Configuration
+		expecetedConfiguration types.Configuration
 	}{
 		{
 			name:                   "empty interface",
 			ok:                     false,
-			expecetedConfiguration: config.Configuration{},
+			expecetedConfiguration: types.Configuration{},
 		},
 		{
 			name:                   "empty map",
 			i:                      map[string]interface{}{},
 			ok:                     true,
-			expecetedConfiguration: config.Configuration{},
+			expecetedConfiguration: types.Configuration{},
 		},
 		{
 			name: "map",
@@ -79,7 +80,7 @@ func TestInterfaceToConfiguration(t *testing.T) {
 				"key2": "value2",
 			},
 			ok: true,
-			expecetedConfiguration: config.Configuration{
+			expecetedConfiguration: types.Configuration{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -92,8 +93,8 @@ func TestInterfaceToConfiguration(t *testing.T) {
 				},
 			},
 			ok: true,
-			expecetedConfiguration: config.Configuration{
-				"key1": config.Configuration{
+			expecetedConfiguration: types.Configuration{
+				"key1": types.Configuration{
 					"key2": "value2",
 				},
 			},
@@ -102,7 +103,7 @@ func TestInterfaceToConfiguration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			vars, ok := config.InterfaceToConfiguration(tc.i)
+			vars, ok := types.InterfaceToConfiguration(tc.i)
 			assert.Equal(t, tc.ok, ok)
 			assert.Equal(t, tc.expecetedConfiguration, vars)
 		})
@@ -112,66 +113,66 @@ func TestInterfaceToConfiguration(t *testing.T) {
 func TestMergeConfiguration(t *testing.T) {
 	testCases := []struct {
 		name     string
-		base     config.Configuration
-		override config.Configuration
-		expected config.Configuration
+		base     types.Configuration
+		override types.Configuration
+		expected types.Configuration
 	}{
 		{
 			name:     "nil base",
-			expected: config.Configuration{},
+			expected: types.Configuration{},
 		},
 		{
 			name:     "empty base and override",
-			base:     config.Configuration{},
-			expected: config.Configuration{},
+			base:     types.Configuration{},
+			expected: types.Configuration{},
 		},
 		{
 			name:     "merge into empty base",
-			base:     config.Configuration{},
-			override: config.Configuration{"key1": "value1"},
-			expected: config.Configuration{"key1": "value1"},
+			base:     types.Configuration{},
+			override: types.Configuration{"key1": "value1"},
+			expected: types.Configuration{"key1": "value1"},
 		},
 		{
 			name:     "merge into base",
-			base:     config.Configuration{"key1": "value1"},
-			override: config.Configuration{"key2": "value2"},
-			expected: config.Configuration{"key1": "value1", "key2": "value2"},
+			base:     types.Configuration{"key1": "value1"},
+			override: types.Configuration{"key2": "value2"},
+			expected: types.Configuration{"key1": "value1", "key2": "value2"},
 		},
 		{
 			name:     "override base, change schema",
-			base:     config.Configuration{"key1": config.Configuration{"key2": "value2"}},
-			override: config.Configuration{"key1": "value1"},
-			expected: config.Configuration{"key1": "value1"},
+			base:     types.Configuration{"key1": types.Configuration{"key2": "value2"}},
+			override: types.Configuration{"key1": "value1"},
+			expected: types.Configuration{"key1": "value1"},
 		},
 		{
 			name:     "merge into sub map",
-			base:     config.Configuration{"key1": config.Configuration{"key2": "value2"}},
-			override: config.Configuration{"key1": config.Configuration{"key3": "value3"}},
-			expected: config.Configuration{"key1": config.Configuration{"key2": "value2", "key3": "value3"}},
+			base:     types.Configuration{"key1": types.Configuration{"key2": "value2"}},
+			override: types.Configuration{"key1": types.Configuration{"key3": "value3"}},
+			expected: types.Configuration{"key1": types.Configuration{"key2": "value2", "key3": "value3"}},
 		},
 		{
 			name:     "override sub map value",
-			base:     config.Configuration{"key1": config.Configuration{"key2": "value2"}},
-			override: config.Configuration{"key1": config.Configuration{"key2": "value3"}},
-			expected: config.Configuration{"key1": config.Configuration{"key2": "value3"}},
+			base:     types.Configuration{"key1": types.Configuration{"key2": "value2"}},
+			override: types.Configuration{"key1": types.Configuration{"key2": "value3"}},
+			expected: types.Configuration{"key1": types.Configuration{"key2": "value3"}},
 		},
 		{
 			name:     "override nested sub map",
-			base:     config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key3": "value3"}}},
-			override: config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key3": "value4"}}},
-			expected: config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key3": "value4"}}},
+			base:     types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key3": "value3"}}},
+			override: types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key3": "value4"}}},
+			expected: types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key3": "value4"}}},
 		},
 		{
 			name:     "override nested sub map multiple levels",
-			base:     config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key3": "value3"}}},
-			override: config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key4": "value4"}}, "key5": "value5"},
-			expected: config.Configuration{"key1": config.Configuration{"key2": config.Configuration{"key3": "value3", "key4": "value4"}}, "key5": "value5"},
+			base:     types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key3": "value3"}}},
+			override: types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key4": "value4"}}, "key5": "value5"},
+			expected: types.Configuration{"key1": types.Configuration{"key2": types.Configuration{"key3": "value3", "key4": "value4"}}, "key5": "value5"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := config.MergeConfiguration(tc.base, tc.override)
+			result := types.MergeConfiguration(tc.base, tc.override)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -189,6 +190,7 @@ func TestPreprocessContent(t *testing.T) {
 			"clustersService": map[string]any{
 				"imageTag": "cs-image",
 			},
+			"availabilityZoneCount": 3,
 		},
 	)
 	assert.Nil(t, err)

--- a/pkg/config/ev2config/config.go
+++ b/pkg/config/ev2config/config.go
@@ -5,7 +5,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	coreconfig "github.com/Azure/ARO-Tools/pkg/config"
+	"github.com/Azure/ARO-Tools/pkg/config/types"
 
 	_ "embed"
 )
@@ -28,21 +28,21 @@ func AllContexts() (map[string][]string, error) {
 	return contexts, nil
 }
 
-func ResolveConfig(cloud, region string) (coreconfig.Configuration, error) {
+func ResolveConfig(cloud, region string) (types.Configuration, error) {
 	ev2Config := config{}
 	if err := yaml.Unmarshal(rawConfig, &ev2Config); err != nil {
 		return nil, fmt.Errorf("failed to parse embedded Ev2 config: %w", err)
 	}
-	cfg := coreconfig.Configuration{}
+	cfg := types.Configuration{}
 	cloudCfg, hasCloud := ev2Config.Clouds[cloud]
 	if !hasCloud {
 		return nil, fmt.Errorf("failed to find cloud %s", cloud)
 	}
-	coreconfig.MergeConfiguration(cfg, cloudCfg.Defaults)
+	types.MergeConfiguration(cfg, cloudCfg.Defaults)
 	regionCfg, hasRegion := cloudCfg.Regions[region]
 	if !hasRegion {
 		return nil, fmt.Errorf("failed to find region %s in cloud %s", region, cloud)
 	}
-	coreconfig.MergeConfiguration(cfg, regionCfg)
+	types.MergeConfiguration(cfg, regionCfg)
 	return cfg, nil
 }

--- a/pkg/config/ev2config/types.go
+++ b/pkg/config/ev2config/types.go
@@ -1,12 +1,14 @@
 package ev2config
 
-import coreconfig "github.com/Azure/ARO-Tools/pkg/config"
+import (
+	"github.com/Azure/ARO-Tools/pkg/config/types"
+)
 
 type config struct {
 	Clouds map[string]SanitizedCloudConfig `json:"clouds"`
 }
 
 type SanitizedCloudConfig struct {
-	Defaults coreconfig.Configuration            `json:"defaults"`
-	Regions  map[string]coreconfig.Configuration `json:"regions"`
+	Defaults types.Configuration            `json:"defaults"`
+	Regions  map[string]types.Configuration `json:"regions"`
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -15,43 +15,25 @@
 package config
 
 import (
-	"strings"
+	"github.com/Azure/ARO-Tools/pkg/config/types"
 )
 
-// Configuration is the top-level container for all values for all services. See an example at: https://github.com/Azure/ARO-HCP/blob/main/config/config.yaml
-type Configuration map[string]any
-
-func (v Configuration) GetByPath(path string) (any, bool) {
-	keys := strings.Split(path, ".")
-	var current any = v
-
-	for _, key := range keys {
-		if m, ok := current.(Configuration); ok {
-			current, ok = m[key]
-			if !ok {
-				return nil, false
-			}
-		} else {
-			return nil, false
-		}
-	}
-
-	return current, true
-}
+// DEPRECATED: use the exported type from types package instead
+type Configuration = types.Configuration
 
 // configurationOverrides is the internal representation for config stored on disk - we do not export it as we
 // require that users pre-process it first, which the ConfigProvider.GetResolver() will do for them.
 type configurationOverrides struct {
-	Schema   string        `json:"$schema"`
-	Defaults Configuration `json:"defaults"`
+	Schema   string              `json:"$schema"`
+	Defaults types.Configuration `json:"defaults"`
 	// key is the cloud alias
 	Overrides map[string]*struct {
-		Defaults Configuration `json:"defaults"`
+		Defaults types.Configuration `json:"defaults"`
 		// key is the deploy env
 		Overrides map[string]*struct {
-			Defaults Configuration `json:"defaults"`
+			Defaults types.Configuration `json:"defaults"`
 			// key is the region name
-			Overrides map[string]Configuration `json:"regions"`
+			Overrides map[string]types.Configuration `json:"regions"`
 		} `json:"environments"`
 	} `json:"clouds"`
 }

--- a/pkg/config/types/configuration.go
+++ b/pkg/config/types/configuration.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Configuration is the top-level container for all values for all services. See an example at: https://github.com/Azure/ARO-HCP/blob/main/config/config.yaml
+type Configuration map[string]any
+
+func (v Configuration) GetByPath(path string) (any, bool) {
+	keys := strings.Split(path, ".")
+	var current any = v
+
+	for _, key := range keys {
+		if m, ok := current.(Configuration); ok {
+			current, ok = m[key]
+			if !ok {
+				return nil, false
+			}
+		} else {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// InterfaceToConfiguration, pass in an interface of map[string]any and get (Configuration, true) back
+// This is also converting nested maps, making it easier to iterate over the configuration.
+// If type does not match, second return value will be false
+func InterfaceToConfiguration(i interface{}) (Configuration, bool) {
+	// Helper, that reduces need for reflection calls, i.e. MapIndex
+	// from: https://github.com/peterbourgon/mergemap/blob/master/mergemap.go
+	value := reflect.ValueOf(i)
+	if value.Kind() == reflect.Map {
+		m := Configuration{}
+		for _, k := range value.MapKeys() {
+			v := value.MapIndex(k).Interface()
+			if nestedMap, ok := InterfaceToConfiguration(v); ok {
+				m[k.String()] = nestedMap
+			} else {
+				m[k.String()] = v
+			}
+		}
+		return m, true
+	}
+	return Configuration{}, false
+}
+
+// Merges Configuration, returns merged Configuration
+// However the return value is only used for recursive updates on the map
+// The actual merged Configuration are updated in the base map
+func MergeConfiguration(base, override Configuration) Configuration {
+	if base == nil {
+		base = Configuration{}
+	}
+	if override == nil {
+		override = Configuration{}
+	}
+	for k, newValue := range override {
+		if baseValue, exists := base[k]; exists {
+			srcMap, srcMapOk := InterfaceToConfiguration(newValue)
+			dstMap, dstMapOk := InterfaceToConfiguration(baseValue)
+			if srcMapOk && dstMapOk {
+				newValue = MergeConfiguration(dstMap, srcMap)
+			}
+		}
+		base[k] = newValue
+	}
+
+	return base
+}

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -14,19 +14,23 @@
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Azure/ARO-Tools/pkg/config/types"
+)
 
 func TestGetByPath(t *testing.T) {
 	tests := []struct {
 		name  string
-		vars  Configuration
+		vars  types.Configuration
 		path  string
 		want  any
 		found bool
 	}{
 		{
 			name: "simple",
-			vars: Configuration{
+			vars: types.Configuration{
 				"key": "value",
 			},
 			path:  "key",
@@ -35,8 +39,8 @@ func TestGetByPath(t *testing.T) {
 		},
 		{
 			name: "nested",
-			vars: Configuration{
-				"key": Configuration{
+			vars: types.Configuration{
+				"key": types.Configuration{
 					"key": "value",
 				},
 			},

--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/Azure/ARO-Tools/pkg/config"
+	types2 "github.com/Azure/ARO-Tools/pkg/config/types"
 )
 
 type Pipeline struct {
@@ -39,7 +40,7 @@ type Pipeline struct {
 //   - A pointer to a new Pipeline instance if successful.
 //   - An error if there was a problem preprocessing the file, validating the schema,
 //     unmarshaling the pipeline, or validating the pipeline instance.
-func NewPipelineFromFile(pipelineFilePath string, cfg config.Configuration) (*Pipeline, error) {
+func NewPipelineFromFile(pipelineFilePath string, cfg types2.Configuration) (*Pipeline, error) {
 	bytes, err := config.PreprocessFile(pipelineFilePath, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to preprocess pipeline file: %w", err)

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -19,7 +19,7 @@ defaults:
   provider: Self
   cloudEnv: '{{ .ctx.cloud }}-{{ .ctx.environment }}'
   vaultDomainSuffix: '{{ .ev2.keyVault.domainNameSuffix }}'
-  availabilityZoneCount: '{{ .ev2.availabilityZoneCount }}'
+  availabilityZoneCount: {{ .ev2.availabilityZoneCount }}
   enableOptionalStep: false
 clouds:
   fairfax:

--- a/testdata/test.bicepparam
+++ b/testdata/test.bicepparam
@@ -8,3 +8,5 @@ param baseDNSZoneResourceGroup = 'global'
 // CS
 param csImage = '{{ .clustersService.imageTag }}'
 param regionRG = '{{ .regionRG }}'
+
+param azCount = {{ .availabilityZoneCount }}

--- a/testdata/zz_fixture_TestConfigProvider.yaml
+++ b/testdata/zz_fixture_TestConfigProvider.yaml
@@ -1,6 +1,6 @@
 aksName: aro-hcp-aks
 aroDevopsMsiId: /subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity
-availabilityZoneCount: "3"
+availabilityZoneCount: 3
 childZone: child.example.com
 cloudEnv: public-int
 clustersService:

--- a/testdata/zz_fixture_TestPreprocessContent.bicepparam
+++ b/testdata/zz_fixture_TestPreprocessContent.bicepparam
@@ -8,3 +8,5 @@ param baseDNSZoneResourceGroup = 'global'
 // CS
 param csImage = 'cs-image'
 param regionRG = 'bahamas'
+
+param azCount = 3


### PR DESCRIPTION
We want to be able to load the whole config file before the user knows what cloud/env/region they want, since we have a lot of cases where we want to operate over all the cloud/env/regions in the config. Previously, we had said that the whole config file needs to parse as valid YAML before templating, but this unfortunately means you cannot use templates for non-string values, which is a non-starter.

We can instead run the file through a dummy template step that replaces values with some cloud/env/region and - since the type we return for the config provider can't do anything except for divulge the contexts - we can just do the correct templating later.

This refactor required pulling the types into a shared package to break import cycles, since ev2config package uses types from config package.