### PR TITLE
pipeline: allow specifying a build step

### DIFF
--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -28,6 +28,17 @@ type Pipeline struct {
 	ServiceGroup   string           `json:"serviceGroup"`
 	RolloutName    string           `json:"rolloutName"`
 	ResourceGroups []*ResourceGroup `json:"resourceGroups"`
+	BuildStep      *BuildStep       `json:"buildStep,omitempty"`
+}
+
+// BuildStep describes how artifacts should be built before any shell steps are run. The command specified here
+// will run with the working directory set to the directory holding this pipeline specification.
+type BuildStep struct {
+	// Command is the command to run for the build step.
+	Command string `json:"command"`
+
+	// Args are the command-line arguments to pass to the build step.
+	Args []string `json:"args"`
 }
 
 // NewPipelineFromFile prepocesses and creates a new Pipeline instance from a file.

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -1,6 +1,10 @@
 $schema: pipeline.schema.v1
 serviceGroup: Microsoft.Azure.ARO.Test
 rolloutName: Test Rollout
+buildStep:
+  command: 'make'
+  args:
+    - build
 resourceGroups:
 - name: '{{ .regionRG  }}'
   subscription: '{{ .svc.subscription.key }}'

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -1,4 +1,8 @@
 $schema: pipeline.schema.v1
+buildStep:
+  args:
+  - build
+  command: make
 resourceGroups:
 - name: hcp-underlay-uks
   steps:


### PR DESCRIPTION
We need to allow pipelines to compile artifacts for use in their shell steps. For now, we will support this with a simple command.