### PR TITLE
ImageMirror step name fix

### DIFF
--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -47,7 +47,7 @@ func (s *ImageMirrorStep) Description() string {
 func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (*ShellStep, error) {
 	return &ShellStep{
 		StepMeta: StepMeta{
-			Name:   "image-mirror",
+			Name:   input.Name,
 			Action: "Shell",
 		},
 		Command: scriptFile,
@@ -83,10 +83,10 @@ func namedVariable(name string, value Value) Variable {
 }
 
 // NewImageMirrorStep creates a new image mirror step.
-func NewImageMirrorStep() *ImageMirrorStep {
+func NewImageMirrorStep(name string) *ImageMirrorStep {
 	return &ImageMirrorStep{
 		StepMeta: StepMeta{
-			Name:   "image-mirror",
+			Name:   name,
 			Action: "ImageMirror",
 		},
 	}

--- a/pkg/types/imagemirror_test.go
+++ b/pkg/types/imagemirror_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-Tools/internal/testutil"
+)
+
+func TestResolveImageMirrorStep(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      ImageMirrorStep
+		scriptFile string
+	}{
+		{
+			name: "image-mirror-step",
+			input: ImageMirrorStep{
+				StepMeta: StepMeta{
+					Name:   "image-mirror-step",
+					Action: "ImageMirror",
+				},
+				TargetACR:          Value{Value: "myacr.azurecr.io"},
+				SourceRegistry:     Value{Value: "docker.io"},
+				Repository:         Value{Value: "nginx"},
+				Digest:             Value{Value: "sha256:123456"},
+				PullSecretKeyVault: Value{Value: "my-keyvault"},
+				PullSecretName:     Value{Value: "my-pull-secret"},
+				ShellIdentity:      Value{Value: "my-identity"},
+			},
+			scriptFile: "/path/to/script.sh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolveImageMirrorStep(tt.input, tt.scriptFile)
+			if err != nil {
+				t.Fatalf("ResolveImageMirrorStep() error = %v", err)
+			}
+
+			testutil.CompareWithFixture(t, result, testutil.WithExtension(".yaml"))
+		})
+	}
+}

--- a/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
+++ b/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
@@ -1,0 +1,22 @@
+action: Shell
+command: /path/to/script.sh
+dryRun:
+  variables:
+  - name: DRY_RUN
+    value: "true"
+name: image-mirror-step
+shellIdentity:
+  value: my-identity
+variables:
+- name: TARGET_ACR
+  value: myacr.azurecr.io
+- name: SOURCE_REGISTRY
+  value: docker.io
+- name: REPOSITORY
+  value: nginx
+- name: DIGEST
+  value: sha256:123456
+- name: PULL_SECRET_KV
+  value: my-keyvault
+- name: PULL_SECRET
+  value: my-pull-secret


### PR DESCRIPTION
the resulting shell step name of an image mirror step was hardcoded to `image-mirror`, which prevented step dependencies to resolve properly within EV2. this PR uses the actuall image mirror step name as the shell step name.