### PR TITLE
Use /bin/bash to invoke Image Mirror Step scripts

### DIFF
--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -50,7 +50,7 @@ func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (*ShellSte
 			Name:   input.Name,
 			Action: "Shell",
 		},
-		Command: scriptFile,
+		Command: fmt.Sprintf("/bin/bash %s", scriptFile),
 		Variables: []Variable{
 			namedVariable("TARGET_ACR", input.TargetACR),
 			namedVariable("SOURCE_REGISTRY", input.SourceRegistry),

--- a/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
+++ b/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
@@ -1,5 +1,5 @@
 action: Shell
-command: /path/to/script.sh
+command: /bin/bash /path/to/script.sh
 dryRun:
   variables:
   - name: DRY_RUN


### PR DESCRIPTION
Previously, consuming repositories invoked scripts like `script.sh` after `cd` into the script directory. This fails because `script.sh` is not in $PATH, and the shell does not assume `./script.sh`.

By explicitly running `/bin/bash script.sh`, we support all cases:
- full path: `/path/to/script.sh`
- relative path: `path/to/script.sh`
- current directory: `./script.sh` or just `script.sh`

This makes script invocation more robust regardless of how the script path is passed in.

NOTE: I'm unsure if this is the best place for this fix as it could also go in [sdp-pipelines/tooling/pkg/types/pipeline/imagemirror.go](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines?path=/tooling/pkg/types/pipeline/imagemirror.go&version=GBmain&line=33&lineEnd=34&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents).  