### PR TITLE
pkg/config: stop special-casing the Configuration type

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,30 +183,10 @@ type configResolver struct {
 	path               string
 }
 
-// InterfaceToConfiguration, pass in an interface of map[string]any and get (Configuration, true) back
-// DEPRECATED: use the exported function from types package instead
-func InterfaceToConfiguration(i interface{}) (Configuration, bool) {
-	return types.InterfaceToConfiguration(i)
-}
-
 // Merges Configuration, returns merged Configuration
 // DEPRECATED: use the exported function from types package instead
 func MergeConfiguration(base, override Configuration) Configuration {
 	return types.MergeConfiguration(base, override)
-}
-
-// Needed to convert Configuration to map[string]interface{} for jsonschema validation
-// see: https://github.com/santhosh-tekuri/jsonschema/blob/boon/schema.go#L124
-func convertToInterface(config types.Configuration) map[string]any {
-	m := map[string]any{}
-	for k, v := range config {
-		if subMap, ok := v.(types.Configuration); ok {
-			m[k] = convertToInterface(subMap)
-		} else {
-			m[k] = v
-		}
-	}
-	return m
 }
 
 func (cr *configResolver) ValidateSchema(config types.Configuration) error {
@@ -224,7 +204,7 @@ func (cr *configResolver) ValidateSchema(config types.Configuration) error {
 		return fmt.Errorf("failed to compile schema: %v", err)
 	}
 
-	err = sch.Validate(convertToInterface(config))
+	err = sch.Validate(map[string]any(config))
 	if err != nil {
 		return fmt.Errorf("failed to validate schema: %v", err)
 	}

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -3,10 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/Azure/ARO-Tools/pkg/config/types"
 )
 
 func TestValidateSchema(t *testing.T) {
@@ -26,25 +23,4 @@ func TestValidateSchema(t *testing.T) {
 
 	validationErr := resolver.ValidateSchema(cfg)
 	require.NoError(t, validationErr)
-}
-
-func TestConvertToInterface(t *testing.T) {
-	vars := types.Configuration{
-		"key1": "value1",
-		"key2": types.Configuration{
-			"key3": "value3",
-		},
-	}
-
-	expected := map[string]any{
-		"key1": "value1",
-		"key2": map[string]any{
-			"key3": "value3",
-		},
-	}
-
-	result := convertToInterface(vars)
-	assert.Equal(t, expected, result)
-	assert.IsType(t, expected, map[string]any{})
-	assert.IsType(t, expected["key2"], map[string]any{})
 }


### PR DESCRIPTION
We do not gain anything by aliasing map[string]any to a type and requiring that nested keys have the aliased type, as opposed to just doing an assertion that when we do a key lookup, the chain of maps that we do lookups in are string-key maps.