### PR TITLE
pkg/types: expose role assignment for subscription provisioning

### DIFF
--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -147,10 +147,14 @@
                             },
                             "certificateDomains": {
                                 "$ref": "#/definitions/value"
+                            },
+                            "roleAssignment": {
+                                "type": "string"
                             }
                         },
                         "required": [
-                            "displayName"
+                            "displayName",
+                            "roleAssignment"
                         ]
                     },
                     "steps": {

--- a/pkg/types/subscription.go
+++ b/pkg/types/subscription.go
@@ -4,6 +4,11 @@ type SubscriptionProvisioning struct {
 	DisplayName                   Value  `json:"displayName"`
 	AIRSRegisteredUserPrincipalId *Value `json:"airsRegisteredUserPrincipalId,omitempty"`
 	CertificateDomains            *Value `json:"certificateDomains,omitempty"`
+
+	// RoleAssignmentParameters is a relative path to the .bicepparam file used to deploy the bootstrapping role-assignments
+	// for this subscription. Keep in mind that once Ev2 marks a subscription as provisioned, this will not run, so the contents
+	// of this ARM template cannot change over time as the template will not be re-executed on existing subscriptions.
+	RoleAssignmentParameters string `json:"roleAssignment,omitempty"`
 }
 
 func (s *SubscriptionProvisioning) Validate() error {

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -15,6 +15,7 @@ resourceGroups:
       configRef: .svc.subscription.airsRegisteredUserPrincipalId
     certificateDomains:
       configRef: .svc.subscription.certificateDomains
+    roleAssignment: 'test.bicepparam'
   steps:
   - name: deploy
     action: Shell
@@ -182,6 +183,7 @@ resourceGroups:
   subscriptionProvisioning:
     displayName:
       configRef: .svc.subscription.displayName
+    roleAssignment: 'test.bicepparam'
   steps:
     - name: image-mirror-ii
       action: ImageMirror

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -176,6 +176,7 @@ resourceGroups:
       configRef: .svc.subscription.certificateDomains
     displayName:
       configRef: .svc.subscription.displayName
+    roleAssignment: test.bicepparam
 - name: global
   steps:
   - action: ImageMirror
@@ -198,5 +199,6 @@ resourceGroups:
   subscriptionProvisioning:
     displayName:
       configRef: .svc.subscription.displayName
+    roleAssignment: test.bicepparam
 rolloutName: Test Rollout
 serviceGroup: Microsoft.Azure.ARO.Test


### PR DESCRIPTION
We need to be able to deploy an ARM template for the bare minimum role assignments in new subscriptions, giving our Ev2 service principal permissions to deploy other content.