### PR TITLE
pkg/types: ask the user for AKV and secret name, not URL

### DIFF
--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -68,11 +68,12 @@ func (s *DelegateChildZoneStep) Description() string {
 }
 
 type SetCertificateIssuerStep struct {
-	StepMeta      `json:",inline"`
-	VaultBaseUrl  Value `json:"vaultBaseUrl,omitempty"`
-	Issuer        Value `json:"issuer,omitempty"`
-	SecretId      Value `json:"secretId,omitempty"`
-	ApplicationId Value `json:"applicationId,omitempty"`
+	StepMeta       `json:",inline"`
+	VaultBaseUrl   Value `json:"vaultBaseUrl,omitempty"`
+	Issuer         Value `json:"issuer,omitempty"`
+	SecretKeyVault Value `json:"secretKeyVault,omitempty"`
+	SecretName     Value `json:"secretName,omitempty"`
+	ApplicationId  Value `json:"applicationId,omitempty"`
 }
 
 func (s *SetCertificateIssuerStep) Description() string {
@@ -86,7 +87,8 @@ type CreateCertificateStep struct {
 	ContentType     Value `json:"contentType,omitempty"`
 	SAN             Value `json:"san,omitempty"`
 	Issuer          Value `json:"issuer,omitempty"`
-	SecretId        Value `json:"secretId,omitempty"`
+	SecretKeyVault  Value `json:"secretKeyVault,omitempty"`
+	SecretName      Value `json:"secretName,omitempty"`
 	ApplicationId   Value `json:"applicationId,omitempty"`
 }
 
@@ -106,7 +108,8 @@ func (s *ResourceProviderRegistrationStep) Description() string {
 type LogsStep struct {
 	StepMeta        `json:",inline"`
 	TypeName        Value             `json:"typeName"`
-	SecretId        Value             `json:"secretId"`
+	SecretKeyVault  Value             `json:"secretKeyVault,omitempty"`
+	SecretName      Value             `json:"secretName,omitempty"`
 	Environment     Value             `json:"environment"`
 	AccountName     Value             `json:"accountName"`
 	MetricsAccount  Value             `json:"metricsAccount"`
@@ -125,8 +128,10 @@ func (s *LogsStep) Description() string {
 }
 
 type FeatureRegistrationStep struct {
-	StepMeta     `json:",inline"`
-	FeatureFlags Value `json:"featureFlags,omitempty"`
+	StepMeta       `json:",inline"`
+	SecretKeyVault Value `json:"secretKeyVault,omitempty"`
+	SecretName     Value `json:"secretName,omitempty"`
+	FeatureFlags   Value `json:"featureFlags,omitempty"`
 }
 
 func (s *FeatureRegistrationStep) Description() string {

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -312,7 +312,10 @@
                                         "issuer": {
                                             "$ref": "#/definitions/value"
                                         },
-                                        "secretId": {
+                                        "secretKeyVault": {
+                                            "$ref": "#/definitions/value"
+                                        },
+                                        "secretName": {
                                             "$ref": "#/definitions/value"
                                         },
                                         "applicationId": {
@@ -328,7 +331,8 @@
                                     "required": [
                                         "vaultBaseUrl",
                                         "issuer",
-                                        "secretId",
+                                        "secretKeyVault",
+                                        "secretName",
                                         "applicationId"
                                     ]
                                 },
@@ -356,7 +360,10 @@
                                         "issuer": {
                                             "$ref": "#/definitions/value"
                                         },
-                                        "secretId": {
+                                        "secretKeyVault": {
+                                            "$ref": "#/definitions/value"
+                                        },
+                                        "secretName": {
                                             "$ref": "#/definitions/value"
                                         },
                                         "applicationId": {
@@ -375,7 +382,8 @@
                                         "contentType",
                                         "san",
                                         "issuer",
-                                        "secretId",
+                                        "secretKeyVault",
+                                        "secretName",
                                         "applicationId"
                                     ]
                                 },
@@ -415,8 +423,11 @@
                                         "typeName":  {
                                             "$ref": "#/definitions/value"
                                         },
-                                        "secretId":  {
-                                            "$ref":  "#/definitions/value"
+                                        "secretKeyVault": {
+                                            "$ref": "#/definitions/value"
+                                        },
+                                        "secretName": {
+                                            "$ref": "#/definitions/value"
                                         },
                                         "environment":  {
                                             "$ref":  "#/definitions/value"
@@ -469,7 +480,8 @@
                                     },
                                     "required": [
                                         "typeName",
-                                        "secretId",
+                                        "secretKeyVault",
+                                        "secretName",
                                         "environment",
                                         "accountName",
                                         "metricsAccount",
@@ -542,6 +554,12 @@
                                         "featureFlags" : {
                                             "$ref": "#/definitions/value"
                                         },
+                                        "secretKeyVault": {
+                                            "$ref": "#/definitions/value"
+                                        },
+                                        "secretName": {
+                                            "$ref": "#/definitions/value"
+                                        },
                                         "dependsOn": {
                                             "type": "array",
                                             "items": {
@@ -550,6 +568,8 @@
                                         }
                                     },
                                     "required": [
+                                        "secretKeyVault",
+                                        "secretName",
                                         "featureFlags"
                                     ]
                                 }

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -35,7 +35,9 @@ defaults:
   enableOptionalStep: false
   ev2:
     assistedId:
-      certificate: https://aro-ev2-admin-int-kv.vault.azure.net/secrets/aro-ev2-admin-int-cert
+      certificate:
+        keyVault: aro-ev2-admin-int-kv
+        name: aro-ev2-admin-int-cert
       applicationId: 0cfe7b03-3a43-4f68-84a0-2a4d9227d5ee
   geneva:
     logs:

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -59,8 +59,10 @@ resourceGroups:
     - deploy
   - name: issuerTest
     action: SetCertificateIssuer
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     applicationId:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
@@ -71,8 +73,10 @@ resourceGroups:
     - deploy
   - name: issuerTestOutputChaining
     action: SetCertificateIssuer
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     applicationId:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
@@ -85,8 +89,10 @@ resourceGroups:
     - deploy
   - name: cert
     action: CreateCertificate
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     applicationId:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
@@ -110,8 +116,10 @@ resourceGroups:
     action: RPLogsAccount
     typeName:
       configRef: geneva.logs.typeName
-    secretId:
-      configRef: geneva.logs.rp.accountCert
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     environment:
       configRef: geneva.logs.environment
     accountName:
@@ -138,8 +146,10 @@ resourceGroups:
     action: ClusterLogsAccount
     typeName:
       configRef: geneva.logs.typeName
-    secretId:
-      configRef: geneva.logs.cluster.accountCert
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     environment:
       configRef: geneva.logs.environment
     accountName:
@@ -187,6 +197,10 @@ resourceGroups:
   steps:
     - name: register-afec-flags
       action: FeatureRegistration
+      secretKeyVault:
+        configRef: ev2.assistedId.certificate.keyVault
+      secretName:
+        configRef: ev2.assistedId.certificate.name
       featureFlags:
         configRef: svc.subscription.afecFlags
     - name: image-mirror-ii

--- a/testdata/zz_fixture_TestConfigProvider.yaml
+++ b/testdata/zz_fixture_TestConfigProvider.yaml
@@ -10,7 +10,9 @@ enableOptionalStep: false
 ev2:
   assistedId:
     applicationId: 0cfe7b03-3a43-4f68-84a0-2a4d9227d5ee
-    certificate: https://aro-ev2-admin-int-kv.vault.azure.net/secrets/aro-ev2-admin-int-cert
+    certificate:
+      keyVault: aro-ev2-admin-int-kv
+      name: aro-ev2-admin-int-cert
 geneva:
   logs:
     administrators:

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -55,8 +55,10 @@ resourceGroups:
     issuer:
       configRef: provider
     name: issuerTest
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     vaultBaseUrl:
       configRef: vaultBaseUrl
   - action: SetCertificateIssuer
@@ -67,8 +69,10 @@ resourceGroups:
     issuer:
       value: provider
     name: issuerTestOutputChaining
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     vaultBaseUrl:
       input:
         name: kvUrl
@@ -85,8 +89,10 @@ resourceGroups:
     name: cert
     san:
       value: hcp-mdsd.geneva.keyvault.aro-int.azure.com
-    secretId:
-      configRef: ev2.assistedId.certificate
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     vaultBaseUrl:
       value: https://arohcp-svc-ln.vault.azure.net
   - action: ResourceProviderRegistration
@@ -118,8 +124,10 @@ resourceGroups:
     name: rpAccount
     namespace:
       value: ns
-    secretId:
-      configRef: geneva.logs.rp.accountCert
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     subscriptionId:
       value: sub
     typeName:
@@ -146,8 +154,10 @@ resourceGroups:
     name: clusterAccount
     namespace:
       value: ns
-    secretId:
-      configRef: geneva.logs.cluster.accountCert
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
     subscriptionId:
       value: sub
     typeName:
@@ -183,6 +193,10 @@ resourceGroups:
     featureFlags:
       configRef: svc.subscription.afecFlags
     name: register-afec-flags
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
   - action: ImageMirror
     digest:
       value: digest


### PR DESCRIPTION
When we need the Ev2 assisted identity certificate, we can ask the user for the parts that vary (the KeyVault it's stored in, and the name of the certificate), omit the parts the user has no control over (the KeyVault DNS suffix), and do some string interpolation in the Ev2 generator to pass the URL of the certificate to extensions that need it, while not requiring the service configuration to hold duplicative information.