### PR TITLE
shell: ask for the subnet name, not the whole ID

### DIFF
--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -238,7 +238,7 @@
                                                 "$ref": "#/definitions/variable"
                                             }
                                         },
-                                        "subnetId": {
+                                        "subnetName": {
                                             "type": "string"
                                         },
                                         "shellIdentity": {

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -25,7 +25,7 @@ type ShellStep struct {
 	Variables     []Variable  `json:"variables,omitempty"`
 	DryRun        DryRun      `json:"dryRun,omitempty"`
 	References    []Reference `json:"references,omitempty"`
-	SubnetId      string      `json:"subnetId,omitempty"`
+	SubnetName    string      `json:"subnetName,omitempty"`
 	ShellIdentity Value       `json:"shellIdentity,omitempty"`
 }
 

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -22,6 +22,7 @@ defaults:
   managementClusterRG: hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}
   imageSyncRG: hcp-underlay-{{ .ctx.regionShort }}-imagesync
   aksName: aro-hcp-aks
+  subnetName: subnet
   clustersService:
     imageTag: abcdef
     replicas: 3

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -21,6 +21,7 @@ resourceGroups:
     action: Shell
     command: make deploy
     aksCluster: '{{ .aksName  }}'
+    subnetName: '{{ .subnetName }}'
     shellIdentity:
       configRef: aroDevopsMsiId
     variables:

--- a/testdata/zz_fixture_TestConfigProvider.yaml
+++ b/testdata/zz_fixture_TestConfigProvider.yaml
@@ -46,6 +46,7 @@ region: uksouth
 regionRG: hcp-underlay-uks
 serviceClusterRG: hcp-underlay-uks-svc
 serviceClusterSubscription: hcp-uksouth
+subnetName: subnet
 svc:
   subscription:
     afecFlags:

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -13,6 +13,7 @@ resourceGroups:
     name: deploy
     shellIdentity:
       configRef: aroDevopsMsiId
+    subnetName: subnet
     variables:
     - configRef: maestro_image
       name: MAESTRO_IMAGE


### PR DESCRIPTION
We know exactly which subscription, resource group, etc, the subnet is in, so we can just ask for the subnet name and build the ID in the background.