### PR TITLE
shell,imagemirror: expose identity fields directly

### DIFF
--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -28,13 +28,13 @@ var OnDemandSyncScript []byte
 type ImageMirrorStep struct {
 	StepMeta `json:",inline"`
 
-	TargetACR          Value `json:"targetACR,omitempty"`
-	SourceRegistry     Value `json:"sourceRegistry,omitempty"`
-	Repository         Value `json:"repository,omitempty"`
-	Digest             Value `json:"digest,omitempty"`
-	PullSecretKeyVault Value `json:"pullSecretKeyVault,omitempty"`
-	PullSecretName     Value `json:"pullSecretName,omitempty"`
-	ShellIdentity      Value `json:"shellIdentity,omitempty"`
+	TargetACR          Value    `json:"targetACR,omitempty"`
+	SourceRegistry     Value    `json:"sourceRegistry,omitempty"`
+	Repository         Value    `json:"repository,omitempty"`
+	Digest             Value    `json:"digest,omitempty"`
+	PullSecretKeyVault Value    `json:"pullSecretKeyVault,omitempty"`
+	PullSecretName     Value    `json:"pullSecretName,omitempty"`
+	ShellIdentity      Identity `json:"identity,omitempty"`
 }
 
 func (s *ImageMirrorStep) Description() string {
@@ -129,7 +129,7 @@ func (s *ImageMirrorStep) WithPullSecretName(pullSecretName Value) *ImageMirrorS
 }
 
 // WithShellIdentity fluent method that sets ShellIdentity.
-func (s *ImageMirrorStep) WithShellIdentity(shellIdentity Value) *ImageMirrorStep {
+func (s *ImageMirrorStep) WithShellIdentity(shellIdentity Identity) *ImageMirrorStep {
 	s.ShellIdentity = shellIdentity
 	return s
 }

--- a/pkg/types/imagemirror_test.go
+++ b/pkg/types/imagemirror_test.go
@@ -39,7 +39,11 @@ func TestResolveImageMirrorStep(t *testing.T) {
 				Digest:             Value{Value: "sha256:123456"},
 				PullSecretKeyVault: Value{Value: "my-keyvault"},
 				PullSecretName:     Value{Value: "my-pull-secret"},
-				ShellIdentity:      Value{Value: "my-identity"},
+				ShellIdentity: Identity{
+					Subscription:  "uuid",
+					ResourceGroup: "rg",
+					Name:          "my-identity",
+				},
 			},
 			scriptFile: "/path/to/script.sh",
 		},

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -17,6 +17,26 @@
                 }
             ]
         },
+        "identityReference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subscription": {
+                    "type": "string"
+                },
+                "resourceGroup": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "subscription",
+                "resourceGroup",
+                "name"
+            ]
+        },
         "value": {
             "type": "object",
             "additionalProperties": false,
@@ -241,8 +261,8 @@
                                         "subnetName": {
                                             "type": "string"
                                         },
-                                        "shellIdentity": {
-                                            "$ref": "#/definitions/value"
+                                        "identity": {
+                                            "$ref": "#/definitions/identityReference"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -522,8 +542,8 @@
                                         "pullSecretName" : {
                                             "$ref":  "#/definitions/value"
                                         },
-                                        "shellIdentity" :  {
-                                            "$ref":  "#/definitions/value"
+                                        "identity" :  {
+                                            "$ref": "#/definitions/identityReference"
                                         },
                                         "dependsOn": {
                                             "type": "array",
@@ -539,7 +559,7 @@
                                         "digest",
                                         "pullSecretKeyVault",
                                         "pullSecretName",
-                                        "shellIdentity"
+                                        "identity"
                                     ]
                                 },
                                 {

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -26,7 +26,13 @@ type ShellStep struct {
 	DryRun        DryRun      `json:"dryRun,omitempty"`
 	References    []Reference `json:"references,omitempty"`
 	SubnetName    string      `json:"subnetName,omitempty"`
-	ShellIdentity Value       `json:"shellIdentity,omitempty"`
+	ShellIdentity Identity    `json:"identity,omitempty"`
+}
+
+type Identity struct {
+	Subscription  string `json:"subscription,omitempty"`
+	ResourceGroup string `json:"resourceGroup,omitempty"`
+	Name          string `json:"name,omitempty"`
 }
 
 // Reference represents a configurable reference

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -1,5 +1,9 @@
 $schema: schema.json
 defaults:
+  global:
+    subscriptionId: 5299e6b7-b23b-46c8-8277-dc1147807117
+    rg: global-shared-resources
+    globalMSIName: global-ev2-identity
   aroDevopsMsiId: '/subscriptions/9a53d80e-dae0-4c8a-af90-30575d253127/resourceGroups/global-shared-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/global-ev2-identity'
   region: '{{ .ctx.region  }}'
   serviceClusterSubscription: hcp-{{ .ctx.region }}

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -22,16 +22,20 @@ resourceGroups:
     command: make deploy
     aksCluster: '{{ .aksName  }}'
     subnetName: '{{ .subnetName }}'
-    shellIdentity:
-      configRef: aroDevopsMsiId
+    identity:
+      subscription: "{{ .global.subscriptionId }}"
+      resourceGroup: "{{ .global.rg }}"
+      name: "{{ .global.globalMSIName }}"
     variables:
     - name: MAESTRO_IMAGE
       configRef: maestro_image
   - name: dry-run
     action: Shell
     command: make deploy
-    shellIdentity:
-      configRef: aroDevopsMsiId
+    identity:
+      subscription: "{{ .global.subscriptionId }}"
+      resourceGroup: "{{ .global.rg }}"
+      name: "{{ .global.globalMSIName }}"
     dryRun:
       variables:
       - name: DRY_RUN
@@ -187,8 +191,10 @@ resourceGroups:
       value: pullSecretKeyVault
     pullSecretName:
       value: pullSecretName
-    shellIdentity:
-      value: shellIdentity
+    identity:
+      subscription: "{{ .global.subscriptionId }}"
+      resourceGroup: "{{ .global.rg }}"
+      name: "{{ .global.globalMSIName }}"
 - name: '{{ .globalRG  }}'
   subscription: '{{ .managementClusterSubscription }}'
   subscriptionProvisioning:
@@ -218,5 +224,7 @@ resourceGroups:
         value: pullSecretKeyVault
       pullSecretName:
         value: pullSecretName
-      shellIdentity:
-        value: shellIdentity
+      identity:
+        subscription: "{{ .global.subscriptionId }}"
+        resourceGroup: "{{ .global.rg }}"
+        name: "{{ .global.globalMSIName }}"

--- a/testdata/zz_fixture_TestConfigProvider.yaml
+++ b/testdata/zz_fixture_TestConfigProvider.yaml
@@ -31,6 +31,10 @@ geneva:
       account: clusterMetricsAccount
     rp:
       account: rpMetricsAccount
+global:
+  globalMSIName: global-ev2-identity
+  rg: global-shared-resources
+  subscriptionId: 5299e6b7-b23b-46c8-8277-dc1147807117
 globalRG: global
 imageSyncRG: hcp-underlay-uks-imagesync
 kusto:

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -10,9 +10,11 @@ resourceGroups:
     aksCluster: aro-hcp-aks
     command: make deploy
     dryRun: {}
+    identity:
+      name: global-ev2-identity
+      resourceGroup: global-shared-resources
+      subscription: 5299e6b7-b23b-46c8-8277-dc1147807117
     name: deploy
-    shellIdentity:
-      configRef: aroDevopsMsiId
     subnetName: subnet
     variables:
     - configRef: maestro_image
@@ -27,9 +29,11 @@ resourceGroups:
         value: "3"
       - name: FROM_EV2_CORE
         value: vault.azure.net
+    identity:
+      name: global-ev2-identity
+      resourceGroup: global-shared-resources
+      subscription: 5299e6b7-b23b-46c8-8277-dc1147807117
     name: dry-run
-    shellIdentity:
-      configRef: aroDevopsMsiId
   - action: ARM
     deploymentLevel: ResourceGroup
     name: svc
@@ -166,6 +170,10 @@ resourceGroups:
   - action: ImageMirror
     digest:
       value: digest
+    identity:
+      name: global-ev2-identity
+      resourceGroup: global-shared-resources
+      subscription: 5299e6b7-b23b-46c8-8277-dc1147807117
     name: image-mirror
     pullSecretKeyVault:
       value: pullSecretKeyVault
@@ -173,8 +181,6 @@ resourceGroups:
       value: pullSecretName
     repository:
       value: repository
-    shellIdentity:
-      value: shellIdentity
     sourceRegistry:
       value: sourceRegistry
     targetACR:
@@ -201,6 +207,10 @@ resourceGroups:
   - action: ImageMirror
     digest:
       value: digest
+    identity:
+      name: global-ev2-identity
+      resourceGroup: global-shared-resources
+      subscription: 5299e6b7-b23b-46c8-8277-dc1147807117
     name: image-mirror-ii
     pullSecretKeyVault:
       value: pullSecretKeyVault
@@ -208,8 +218,6 @@ resourceGroups:
       value: pullSecretName
     repository:
       value: repository
-    shellIdentity:
-      value: shellIdentity
     sourceRegistry:
       value: sourceRegistry
     targetACR:

--- a/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
+++ b/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step.yaml
@@ -4,9 +4,11 @@ dryRun:
   variables:
   - name: DRY_RUN
     value: "true"
+identity:
+  name: my-identity
+  resourceGroup: rg
+  subscription: uuid
 name: image-mirror-step
-shellIdentity:
-  value: my-identity
 variables:
 - name: TARGET_ACR
   value: myacr.azurecr.io


### PR DESCRIPTION
We can concatenate the identity fields into an identifier in the processor for the pipeline, so there's no need to record the constituent parts of the identifier as well as the identifier itself in config.