### PR TITLE
feat: add yamlwrap package for quoting unquoted Go templates in YAML

### DIFF
--- a/pkg/yamlwrap/command.go
+++ b/pkg/yamlwrap/command.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlwrap
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/cobra"
+)
+
+func NewWrapCommand() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:           "wrap",
+		Short:         "Wrap Go template expressions in YAML files",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	opts := DefaultOptions()
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, fmt.Errorf("failed to bind options: %w", err)
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer cancel()
+
+		validated, err := opts.Validate()
+		if err != nil {
+			return err
+		}
+		completed, err := validated.Complete()
+		if err != nil {
+			return err
+		}
+		return completed.Wrap(ctx)
+	}
+
+	return cmd, nil
+}
+
+func NewUnwrapCommand() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:           "unwrap",
+		Short:         "Unwrap Go template expressions in YAML files",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	opts := DefaultOptions()
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, fmt.Errorf("failed to bind options: %w", err)
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer cancel()
+
+		validated, err := opts.Validate()
+		if err != nil {
+			return err
+		}
+		completed, err := validated.Complete()
+		if err != nil {
+			return err
+		}
+		return completed.Unwrap(ctx)
+	}
+
+	return cmd, nil
+}

--- a/pkg/yamlwrap/options.go
+++ b/pkg/yamlwrap/options.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlwrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		InPlace:       true,
+		ReplaceOutput: false,
+	}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().BoolVar(&opts.InPlace, "in-place", opts.InPlace, "Process the file in place.")
+	cmd.Flags().StringVar(&opts.InputPath, "input", opts.InputPath, "Path to the input file.")
+	cmd.Flags().StringVar(&opts.OutputPath, "output", opts.OutputPath, "Path to the output file.")
+	cmd.Flags().BoolVar(&opts.ReplaceOutput, "replace-output", opts.ReplaceOutput, "Replace the output file if it exists.")
+	for _, flag := range []string{
+		"input",
+		"output",
+	} {
+		if err := cmd.MarkFlagFilename(flag); err != nil {
+			return fmt.Errorf("failed to mark flag %q as a file: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+// RawOptions holds input values.
+type RawOptions struct {
+	InputPath     string
+	OutputPath    string
+	InPlace       bool
+	ReplaceOutput bool
+}
+
+// validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedOptions struct {
+	InputPath  string
+	OutputPath string
+}
+
+type ValidatedOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedOptions
+}
+
+// completedOptions is a private wrapper that enforces a call of Complete() before Config generation can be invoked.
+type completedOptions struct {
+	InputPath  string
+	OutputPath string
+}
+
+type Options struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedOptions
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	// input file must be specified
+	if o.InputPath == "" {
+		return nil, fmt.Errorf("the file to process must be provided with --input")
+	}
+
+	// ... and must exist
+	if _, err := os.Stat(o.InputPath); err != nil {
+		return nil, fmt.Errorf("input file %q does not exist: %w", o.InputPath, err)
+	}
+
+	// check that either output path or in-place is specified, but not both
+	if o.OutputPath != "" && o.InPlace {
+		return nil, fmt.Errorf("--output and --in-place are mutually exclusive, specify only one")
+	}
+
+	// check that at least one is specified
+	if o.OutputPath == "" && !o.InPlace {
+		return nil, fmt.Errorf("either --output or --in-place must be specified")
+	}
+
+	var outputPath string
+	if o.InPlace {
+		outputPath = o.InputPath
+	} else {
+		outputPath = o.OutputPath
+
+		if stat, err := os.Stat(outputPath); err == nil {
+			if !o.ReplaceOutput {
+				return nil, fmt.Errorf("output file %q already exists, use --replace-output to overwrite", outputPath)
+			}
+			if stat.IsDir() {
+				return nil, fmt.Errorf("output path %q is a directory, cannot overwrite", outputPath)
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to check output file %q: %w", outputPath, err)
+		}
+	}
+
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			InputPath:  o.InputPath,
+			OutputPath: outputPath,
+		},
+	}, nil
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	return &Options{
+		completedOptions: &completedOptions{
+			InputPath:  o.InputPath,
+			OutputPath: o.OutputPath,
+		},
+	}, nil
+}
+
+func (opts *Options) Wrap(ctx context.Context) error {
+	return WrapFile(opts.InputPath, opts.OutputPath)
+}
+
+func (opts *Options) Unwrap(ctx context.Context) error {
+	return UnwrapFile(opts.InputPath, opts.OutputPath)
+}

--- a/pkg/yamlwrap/testdata/unwrapped.yaml
+++ b/pkg/yamlwrap/testdata/unwrapped.yaml
@@ -1,0 +1,121 @@
+# string stuff
+string: string
+doubleQuotedString: "quoted string string"
+singleQuotedString: 'quoted string string'
+doubleQuotedStringWithComment: "quoted string string with comment" # comment
+singleQuotedStringWithComment: 'quoted string string with comment' # comment
+quotedStringWithHash: "string # don't confuse this for a comment"
+quotedStringWithHashAndComment: "string # don't confuse this for a comment" # comment
+
+# int
+integer: 123
+integerComment: 123 # comment
+
+# bool
+bool: true
+boolComment: true # comment
+
+# array
+array:
+- item1
+- item2
+- item-with-tmpl-{{ .value }}
+- item-with-colon-and-template:{{ .Values.metricsPort }}
+
+# templates
+unquotedTemplate: {{ .value }}
+unquotedTemplateWithComment: {{ .value }} # comment
+quotedTemplate: "{{ .value }}"
+quotedTemplateWithComment: "{{ .value }}" # comment
+
+unquotedTemplatePrefix: prefix-{{ .value }}
+unquotedTemplatePrefixWithComment: prefix-{{ .value }} # comment
+quotedTemplatePrefix: "prefix-{{ .value }}"
+quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+unquotedTemplateSuffix: {{ .value }}-suffix
+unquotedTemplateSuffixWithComment: {{ .value }}-suffix # comment
+quotedTemplateSuffix: "{{ .value }}-suffix"
+quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+unquotedTemplateInfix: prefix-{{ .value }}-suffix
+unquotedTemplateInfixWithComment: prefix-{{ .value }}-suffix # comment
+quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+unquotedTemplateWithColon: prefix:{{ .value }}
+
+# array templates
+arrayWithTemplates:
+- {{ .value }}
+- regular_value
+- "{{ .value }}"
+- item-with-colon-and-template:{{ .value }}
+
+# indented array
+indentedArray:
+  - item1
+  - {{ .value }}
+  - regular_value
+  - "{{ .value }}"
+  - item-with-colon-and-template:{{ .value }}
+
+# nested
+nested:
+  # string stuff
+  string: string
+  doubleQuotedString: "quoted string string"
+  singleQuotedString: 'quoted string string'
+  doubleQuotedStringWithComment: "quoted string string with comment" # comment
+  singleQuotedStringWithComment: 'quoted string string with comment' # comment
+
+  # int
+  integer: 123
+  integerComment: 123 # comment
+
+  # bool
+  bool: true
+  boolComment: true # comment
+
+  # array
+  array:
+  - item1
+  - item2
+  - item-with-tmpl-{{ .value }}
+  - item-with-colon-and-template:{{ .Values.metricsPort }}
+
+  # templates
+  unquotedTemplate: {{ .value }}
+  unquotedTemplateWithComment: {{ .value }} # comment
+  quotedTemplate: "{{ .value }}"
+  quotedTemplateWithComment: "{{ .value }}" # comment
+
+  unquotedTemplatePrefix: prefix-{{ .value }}
+  unquotedTemplatePrefixWithComment: prefix-{{ .value }} # comment
+  quotedTemplatePrefix: "prefix-{{ .value }}"
+  quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+  unquotedTemplateSuffix: {{ .value }}-suffix
+  unquotedTemplateSuffixWithComment: {{ .value }}-suffix # comment
+  quotedTemplateSuffix: "{{ .value }}-suffix"
+  quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+  unquotedTemplateInfix: prefix-{{ .value }}-suffix
+  unquotedTemplateInfixWithComment: prefix-{{ .value }}-suffix # comment
+  quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+  quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+  unquotedTemplateWithColon: prefix:{{ .value }}
+
+  # array templates
+  arrayWithTemplates:
+  - {{ .value }}
+  - regular_value
+  - "{{ .value }}"
+  - item-with-colon-and-template:{{ .value }}
+
+  # indented array
+  indentedArray:
+    - item1
+    - {{ .value }}
+    - regular_value
+    - "{{ .value }}"
+    - item-with-colon-and-template:{{ .value }}

--- a/pkg/yamlwrap/testdata/wrapped.yaml
+++ b/pkg/yamlwrap/testdata/wrapped.yaml
@@ -1,0 +1,121 @@
+# string stuff
+string: string
+doubleQuotedString: "quoted string string"
+singleQuotedString: 'quoted string string'
+doubleQuotedStringWithComment: "quoted string string with comment" # comment
+singleQuotedStringWithComment: 'quoted string string with comment' # comment
+quotedStringWithHash: "string # don't confuse this for a comment"
+quotedStringWithHashAndComment: "string # don't confuse this for a comment" # comment
+
+# int
+integer: 123
+integerComment: 123 # comment
+
+# bool
+bool: true
+boolComment: true # comment
+
+# array
+array:
+- item1
+- item2
+- "item-with-tmpl-{{ .value }}" # __WRAPPED_TEMPLATE__
+- "item-with-colon-and-template:{{ .Values.metricsPort }}" # __WRAPPED_TEMPLATE__
+
+# templates
+unquotedTemplate: "{{ .value }}" # __WRAPPED_TEMPLATE__
+unquotedTemplateWithComment: "{{ .value }}" # comment __WRAPPED_TEMPLATE__
+quotedTemplate: "{{ .value }}"
+quotedTemplateWithComment: "{{ .value }}" # comment
+
+unquotedTemplatePrefix: "prefix-{{ .value }}" # __WRAPPED_TEMPLATE__
+unquotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment __WRAPPED_TEMPLATE__
+quotedTemplatePrefix: "prefix-{{ .value }}"
+quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+unquotedTemplateSuffix: "{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+unquotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+quotedTemplateSuffix: "{{ .value }}-suffix"
+quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+unquotedTemplateInfix: "prefix-{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+unquotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+unquotedTemplateWithColon: "prefix:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# array templates
+arrayWithTemplates:
+- "{{ .value }}" # __WRAPPED_TEMPLATE__
+- regular_value
+- "{{ .value }}"
+- "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# indented array
+indentedArray:
+  - item1
+  - "{{ .value }}" # __WRAPPED_TEMPLATE__
+  - regular_value
+  - "{{ .value }}"
+  - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# nested
+nested:
+  # string stuff
+  string: string
+  doubleQuotedString: "quoted string string"
+  singleQuotedString: 'quoted string string'
+  doubleQuotedStringWithComment: "quoted string string with comment" # comment
+  singleQuotedStringWithComment: 'quoted string string with comment' # comment
+
+  # int
+  integer: 123
+  integerComment: 123 # comment
+
+  # bool
+  bool: true
+  boolComment: true # comment
+
+  # array
+  array:
+  - item1
+  - item2
+  - "item-with-tmpl-{{ .value }}" # __WRAPPED_TEMPLATE__
+  - "item-with-colon-and-template:{{ .Values.metricsPort }}" # __WRAPPED_TEMPLATE__
+
+  # templates
+  unquotedTemplate: "{{ .value }}" # __WRAPPED_TEMPLATE__
+  unquotedTemplateWithComment: "{{ .value }}" # comment __WRAPPED_TEMPLATE__
+  quotedTemplate: "{{ .value }}"
+  quotedTemplateWithComment: "{{ .value }}" # comment
+
+  unquotedTemplatePrefix: "prefix-{{ .value }}" # __WRAPPED_TEMPLATE__
+  unquotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment __WRAPPED_TEMPLATE__
+  quotedTemplatePrefix: "prefix-{{ .value }}"
+  quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+  unquotedTemplateSuffix: "{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+  unquotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+  quotedTemplateSuffix: "{{ .value }}-suffix"
+  quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+  unquotedTemplateInfix: "prefix-{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+  unquotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+  quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+  quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+  unquotedTemplateWithColon: "prefix:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+  # array templates
+  arrayWithTemplates:
+  - "{{ .value }}" # __WRAPPED_TEMPLATE__
+  - regular_value
+  - "{{ .value }}"
+  - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+  # indented array
+  indentedArray:
+    - item1
+    - "{{ .value }}" # __WRAPPED_TEMPLATE__
+    - regular_value
+    - "{{ .value }}"
+    - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__

--- a/pkg/yamlwrap/yaml.go
+++ b/pkg/yamlwrap/yaml.go
@@ -1,0 +1,221 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlwrap
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	// WrapperMarker is the comment marker that identifies wrapped template values
+	WrapperMarker = "__WRAPPED_TEMPLATE__"
+)
+
+var (
+	// templatePattern matches Go template expressions like {{ .foo.bar }}
+	// Examples: {{ .value }}, {{.Values.name}}, {{ range .items }}
+	templatePattern = regexp.MustCompile(`{{\s*[^}]+\s*}}`)
+	// fieldWithTemplatePattern matches YAML field values that contain template expressions
+	// Examples: "key: value" -> captures "key:" and "value"
+	//           "  nested: {{ .template }}" -> captures "  nested:" and "{{ .template }}"
+	fieldWithTemplatePattern = regexp.MustCompile(`^(\s*[^:]+:)\s*(.*)$`)
+	// arrayItemPattern matches YAML array items
+	// Examples: "- item" -> captures "-" and "item"
+	//           "  - {{ .value }}" -> captures "  -" and "{{ .value }}"
+	//           "- item-with-colon:value" -> captures "-" and "item-with-colon:value"
+	arrayItemPattern = regexp.MustCompile(`^(\s*-)\s*(.*)$`)
+)
+
+func WrapFile(inputPath string, outputPath string) error {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", inputPath, err)
+	}
+
+	wrapped, err := WrapYAML(data)
+	if err != nil {
+		return fmt.Errorf("failed to wrap YAML: %w", err)
+	}
+
+	err = os.WriteFile(outputPath, wrapped, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file %s: %w", outputPath, err)
+	}
+
+	return nil
+}
+
+func UnwrapFile(inputPath string, outputPath string) error {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", inputPath, err)
+	}
+
+	unwrapped, err := UnwrapYAML(data)
+	if err != nil {
+		return fmt.Errorf("failed to unwrap YAML: %w", err)
+	}
+
+	err = os.WriteFile(outputPath, unwrapped, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file %s: %w", outputPath, err)
+	}
+
+	return nil
+}
+
+func WrapYAML(data []byte) ([]byte, error) {
+	text := string(data)
+
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		// skip if already wrapped
+		if strings.Contains(line, WrapperMarker) {
+			continue
+		}
+
+		// ... or if there is no template in the line
+		if !templatePattern.MatchString(line) {
+			continue
+		}
+
+		var prefix, value string
+
+		// Check array items first to handle cases like "- item:value"
+		// which could match both patterns
+		arrayMatch := arrayItemPattern.FindStringSubmatch(line)
+		if len(arrayMatch) >= 3 {
+			prefix = arrayMatch[1] // "-"
+			value = arrayMatch[2]  // everything after the dash
+		} else {
+			// check if this looks like a YAML field assignment
+			fieldMatch := fieldWithTemplatePattern.FindStringSubmatch(line)
+			if len(fieldMatch) >= 3 {
+				prefix = fieldMatch[1] // "key:"
+				value = fieldMatch[2]  // everything after the colon
+			} else {
+				continue
+			}
+		}
+
+		// Check if the value contains templates
+		if !templatePattern.MatchString(value) {
+			continue
+		}
+
+		// Parse the existing comment if any
+		commentPos := strings.Index(value, "#")
+		var valueContent, comment string
+		if commentPos != -1 {
+			valueContent = strings.TrimSpace(value[:commentPos])
+			comment = value[commentPos:]
+		} else {
+			valueContent = strings.TrimSpace(value)
+			comment = ""
+		}
+
+		// Only wrap if the value contains templates and is not already quoted
+		if templatePattern.MatchString(valueContent) && !isQuoted(valueContent) {
+			// Wrap the unquoted value
+			wrappedValue := "\"" + valueContent + "\""
+
+			// Add wrapper marker
+			if comment != "" {
+				lines[i] = prefix + " " + wrappedValue + " " + comment + " " + WrapperMarker
+			} else {
+				lines[i] = prefix + " " + wrappedValue + " # " + WrapperMarker
+			}
+		}
+	}
+
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+func UnwrapYAML(data []byte) ([]byte, error) {
+	text := string(data)
+
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		// skip lines that don't contain wrapper markers
+		if !strings.Contains(line, WrapperMarker) {
+			continue
+		}
+
+		var prefix, value string
+
+		// Check array items first to handle cases like "- item:value"
+		// which could match both patterns
+		arrayMatch := arrayItemPattern.FindStringSubmatch(line)
+		if len(arrayMatch) >= 3 {
+			prefix = arrayMatch[1] // "-"
+			value = arrayMatch[2]  // everything after the dash
+		} else {
+			// parse the line to find field and value
+			fieldMatch := fieldWithTemplatePattern.FindStringSubmatch(line)
+			if len(fieldMatch) >= 3 {
+				prefix = fieldMatch[1] // "key:"
+				value = fieldMatch[2]  // everything after the colon
+			} else {
+				continue
+			}
+		}
+
+		// Remove the wrapper marker from the line
+		cleanValue := strings.Replace(value, " "+WrapperMarker, "", 1)
+		cleanValue = strings.Replace(cleanValue, WrapperMarker, "", 1)
+		cleanValue = strings.TrimSpace(cleanValue)
+
+		// Check if there's a comment
+		commentPos := strings.Index(cleanValue, "#")
+		var valueContent, comment string
+		if commentPos != -1 {
+			valueContent = strings.TrimSpace(cleanValue[:commentPos])
+			comment = cleanValue[commentPos:]
+		} else {
+			valueContent = strings.TrimSpace(cleanValue)
+			comment = ""
+		}
+
+		// Remove quotes if the value is quoted (since we only wrap unquoted values)
+		if isQuoted(valueContent) {
+			// Remove outer quotes
+			valueContent = strings.TrimSpace(valueContent)
+			if strings.HasPrefix(valueContent, "\"") && strings.HasSuffix(valueContent, "\"") {
+				valueContent = valueContent[1 : len(valueContent)-1]
+			} else if strings.HasPrefix(valueContent, "'") && strings.HasSuffix(valueContent, "'") {
+				valueContent = valueContent[1 : len(valueContent)-1]
+			}
+		}
+
+		// Reconstruct the line
+		if comment != "" && strings.TrimSpace(comment) != "#" {
+			lines[i] = prefix + " " + valueContent + " " + comment
+		} else {
+			lines[i] = prefix + " " + valueContent
+		}
+	}
+
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+// isQuoted checks if a string is surrounded by quotes
+func isQuoted(s string) bool {
+	s = strings.TrimSpace(s)
+	return (strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) ||
+		(strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'"))
+}

--- a/pkg/yamlwrap/yaml_test.go
+++ b/pkg/yamlwrap/yaml_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlwrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-Tools/internal/testutil"
+)
+
+func TestWrapYAML(t *testing.T) {
+	inputPath := filepath.Join("testdata", "unwrapped.yaml")
+	data, err := os.ReadFile(inputPath)
+	require.NoError(t, err)
+
+	result, err := WrapYAML(data)
+	require.NoError(t, err)
+
+	testutil.CompareWithFixture(t, result, testutil.WithExtension(".yaml"))
+}
+
+func TestUnwrapYAML(t *testing.T) {
+	inputPath := filepath.Join("testdata", "wrapped.yaml")
+	data, err := os.ReadFile(inputPath)
+	require.NoError(t, err)
+
+	result, err := UnwrapYAML(data)
+	require.NoError(t, err)
+
+	testutil.CompareWithFixture(t, result, testutil.WithExtension(".yaml"))
+}
+
+func TestRoundTrip(t *testing.T) {
+	// Read the unwrapped.yaml file
+	inputPath := filepath.Join("testdata", "unwrapped.yaml")
+	original, err := os.ReadFile(inputPath)
+	require.NoError(t, err)
+
+	// wrap it in memory
+	wrapped, err := WrapYAML(original)
+	require.NoError(t, err)
+
+	// ... then unwrap
+	result, err := UnwrapYAML(wrapped)
+	require.NoError(t, err)
+
+	// Compare that the round trip produces the same result as the original
+	assert.Empty(t, cmp.Diff(original, result))
+}

--- a/testdata/zz_fixture_TestUnwrapYAML.yaml
+++ b/testdata/zz_fixture_TestUnwrapYAML.yaml
@@ -1,0 +1,121 @@
+# string stuff
+string: string
+doubleQuotedString: "quoted string string"
+singleQuotedString: 'quoted string string'
+doubleQuotedStringWithComment: "quoted string string with comment" # comment
+singleQuotedStringWithComment: 'quoted string string with comment' # comment
+quotedStringWithHash: "string # don't confuse this for a comment"
+quotedStringWithHashAndComment: "string # don't confuse this for a comment" # comment
+
+# int
+integer: 123
+integerComment: 123 # comment
+
+# bool
+bool: true
+boolComment: true # comment
+
+# array
+array:
+- item1
+- item2
+- item-with-tmpl-{{ .value }}
+- item-with-colon-and-template:{{ .Values.metricsPort }}
+
+# templates
+unquotedTemplate: {{ .value }}
+unquotedTemplateWithComment: {{ .value }} # comment
+quotedTemplate: "{{ .value }}"
+quotedTemplateWithComment: "{{ .value }}" # comment
+
+unquotedTemplatePrefix: prefix-{{ .value }}
+unquotedTemplatePrefixWithComment: prefix-{{ .value }} # comment
+quotedTemplatePrefix: "prefix-{{ .value }}"
+quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+unquotedTemplateSuffix: {{ .value }}-suffix
+unquotedTemplateSuffixWithComment: {{ .value }}-suffix # comment
+quotedTemplateSuffix: "{{ .value }}-suffix"
+quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+unquotedTemplateInfix: prefix-{{ .value }}-suffix
+unquotedTemplateInfixWithComment: prefix-{{ .value }}-suffix # comment
+quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+unquotedTemplateWithColon: prefix:{{ .value }}
+
+# array templates
+arrayWithTemplates:
+- {{ .value }}
+- regular_value
+- "{{ .value }}"
+- item-with-colon-and-template:{{ .value }}
+
+# indented array
+indentedArray:
+  - item1
+  - {{ .value }}
+  - regular_value
+  - "{{ .value }}"
+  - item-with-colon-and-template:{{ .value }}
+
+# nested
+nested:
+  # string stuff
+  string: string
+  doubleQuotedString: "quoted string string"
+  singleQuotedString: 'quoted string string'
+  doubleQuotedStringWithComment: "quoted string string with comment" # comment
+  singleQuotedStringWithComment: 'quoted string string with comment' # comment
+
+  # int
+  integer: 123
+  integerComment: 123 # comment
+
+  # bool
+  bool: true
+  boolComment: true # comment
+
+  # array
+  array:
+  - item1
+  - item2
+  - item-with-tmpl-{{ .value }}
+  - item-with-colon-and-template:{{ .Values.metricsPort }}
+
+  # templates
+  unquotedTemplate: {{ .value }}
+  unquotedTemplateWithComment: {{ .value }} # comment
+  quotedTemplate: "{{ .value }}"
+  quotedTemplateWithComment: "{{ .value }}" # comment
+
+  unquotedTemplatePrefix: prefix-{{ .value }}
+  unquotedTemplatePrefixWithComment: prefix-{{ .value }} # comment
+  quotedTemplatePrefix: "prefix-{{ .value }}"
+  quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+  unquotedTemplateSuffix: {{ .value }}-suffix
+  unquotedTemplateSuffixWithComment: {{ .value }}-suffix # comment
+  quotedTemplateSuffix: "{{ .value }}-suffix"
+  quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+  unquotedTemplateInfix: prefix-{{ .value }}-suffix
+  unquotedTemplateInfixWithComment: prefix-{{ .value }}-suffix # comment
+  quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+  quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+  unquotedTemplateWithColon: prefix:{{ .value }}
+
+  # array templates
+  arrayWithTemplates:
+  - {{ .value }}
+  - regular_value
+  - "{{ .value }}"
+  - item-with-colon-and-template:{{ .value }}
+
+  # indented array
+  indentedArray:
+    - item1
+    - {{ .value }}
+    - regular_value
+    - "{{ .value }}"
+    - item-with-colon-and-template:{{ .value }}

--- a/testdata/zz_fixture_TestWrapYAML.yaml
+++ b/testdata/zz_fixture_TestWrapYAML.yaml
@@ -1,0 +1,121 @@
+# string stuff
+string: string
+doubleQuotedString: "quoted string string"
+singleQuotedString: 'quoted string string'
+doubleQuotedStringWithComment: "quoted string string with comment" # comment
+singleQuotedStringWithComment: 'quoted string string with comment' # comment
+quotedStringWithHash: "string # don't confuse this for a comment"
+quotedStringWithHashAndComment: "string # don't confuse this for a comment" # comment
+
+# int
+integer: 123
+integerComment: 123 # comment
+
+# bool
+bool: true
+boolComment: true # comment
+
+# array
+array:
+- item1
+- item2
+- "item-with-tmpl-{{ .value }}" # __WRAPPED_TEMPLATE__
+- "item-with-colon-and-template:{{ .Values.metricsPort }}" # __WRAPPED_TEMPLATE__
+
+# templates
+unquotedTemplate: "{{ .value }}" # __WRAPPED_TEMPLATE__
+unquotedTemplateWithComment: "{{ .value }}" # comment __WRAPPED_TEMPLATE__
+quotedTemplate: "{{ .value }}"
+quotedTemplateWithComment: "{{ .value }}" # comment
+
+unquotedTemplatePrefix: "prefix-{{ .value }}" # __WRAPPED_TEMPLATE__
+unquotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment __WRAPPED_TEMPLATE__
+quotedTemplatePrefix: "prefix-{{ .value }}"
+quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+unquotedTemplateSuffix: "{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+unquotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+quotedTemplateSuffix: "{{ .value }}-suffix"
+quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+unquotedTemplateInfix: "prefix-{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+unquotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+unquotedTemplateWithColon: "prefix:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# array templates
+arrayWithTemplates:
+- "{{ .value }}" # __WRAPPED_TEMPLATE__
+- regular_value
+- "{{ .value }}"
+- "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# indented array
+indentedArray:
+  - item1
+  - "{{ .value }}" # __WRAPPED_TEMPLATE__
+  - regular_value
+  - "{{ .value }}"
+  - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+# nested
+nested:
+  # string stuff
+  string: string
+  doubleQuotedString: "quoted string string"
+  singleQuotedString: 'quoted string string'
+  doubleQuotedStringWithComment: "quoted string string with comment" # comment
+  singleQuotedStringWithComment: 'quoted string string with comment' # comment
+
+  # int
+  integer: 123
+  integerComment: 123 # comment
+
+  # bool
+  bool: true
+  boolComment: true # comment
+
+  # array
+  array:
+  - item1
+  - item2
+  - "item-with-tmpl-{{ .value }}" # __WRAPPED_TEMPLATE__
+  - "item-with-colon-and-template:{{ .Values.metricsPort }}" # __WRAPPED_TEMPLATE__
+
+  # templates
+  unquotedTemplate: "{{ .value }}" # __WRAPPED_TEMPLATE__
+  unquotedTemplateWithComment: "{{ .value }}" # comment __WRAPPED_TEMPLATE__
+  quotedTemplate: "{{ .value }}"
+  quotedTemplateWithComment: "{{ .value }}" # comment
+
+  unquotedTemplatePrefix: "prefix-{{ .value }}" # __WRAPPED_TEMPLATE__
+  unquotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment __WRAPPED_TEMPLATE__
+  quotedTemplatePrefix: "prefix-{{ .value }}"
+  quotedTemplatePrefixWithComment: "prefix-{{ .value }}" # comment
+
+  unquotedTemplateSuffix: "{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+  unquotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+  quotedTemplateSuffix: "{{ .value }}-suffix"
+  quotedTemplateSuffixWithComment: "{{ .value }}-suffix" # comment
+
+  unquotedTemplateInfix: "prefix-{{ .value }}-suffix" # __WRAPPED_TEMPLATE__
+  unquotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment __WRAPPED_TEMPLATE__
+  quotedTemplateInfix: "prefix-{{ .value }}-suffix"
+  quotedTemplateInfixWithComment: "prefix-{{ .value }}-suffix" # comment
+  unquotedTemplateWithColon: "prefix:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+  # array templates
+  arrayWithTemplates:
+  - "{{ .value }}" # __WRAPPED_TEMPLATE__
+  - regular_value
+  - "{{ .value }}"
+  - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__
+
+  # indented array
+  indentedArray:
+    - item1
+    - "{{ .value }}" # __WRAPPED_TEMPLATE__
+    - regular_value
+    - "{{ .value }}"
+    - "item-with-colon-and-template:{{ .value }}" # __WRAPPED_TEMPLATE__


### PR DESCRIPTION
Introduces a new yamlwrap package that automatically wraps unquoted Go template
expressions in YAML files with quotes, preventing YAML parsing errors while
maintaining template functionality.

The package provides:
- WrapYAML/WrapFile: Adds quotes to unquoted template expressions and marks
  them with __WRAPPED_TEMPLATE__ comment for tracking
- UnwrapYAML/UnwrapFile: Removes quotes from wrapped templates to restore 
  original format
- Preserves existing comments and formatting
- Handles edge cases like array items containing colons
- Supports nested structures and various template patterns

This enables safer YAML processing for tools that need to parse YAML files 
containing Go templates (e.g., Helm charts) without breaking template syntax.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>