### PR TITLE
pipeline: apply schema to raw user input before round-tripping

### DIFF
--- a/pkg/types/pipeline.go
+++ b/pkg/types/pipeline.go
@@ -57,6 +57,10 @@ func NewPipelineFromFile(pipelineFilePath string, cfg types2.Configuration) (*Pi
 		return nil, fmt.Errorf("failed to preprocess pipeline file: %w", err)
 	}
 
+	if err := ValidatePipelineSchema(bytes); err != nil {
+		return nil, fmt.Errorf("failed to validate pipeline schema: %w", err)
+	}
+
 	var pipeline Pipeline
 	if err := yaml.Unmarshal(bytes, &pipeline); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pipeline file: %w", err)
@@ -66,9 +70,6 @@ func NewPipelineFromFile(pipelineFilePath string, cfg types2.Configuration) (*Pi
 		return nil, fmt.Errorf("pipeline file failed validation: %w", err)
 	}
 
-	if err = ValidatePipelineSchemaForStruct(&pipeline); err != nil {
-		return nil, fmt.Errorf("pipeline schema validation failed after postprocessing: %w", err)
-	}
 	return &pipeline, nil
 }
 

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -4,15 +4,22 @@
     "type": "object",
     "additionalProperties": false,
     "definitions": {
+        "configRef": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*"
+        },
         "staticVariableValue": {
             "oneOf": [
                 {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 }
             ]
@@ -22,10 +29,12 @@
             "additionalProperties": false,
             "properties": {
                 "step": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 }
             },
             "required": [
@@ -41,7 +50,7 @@
                     "$ref": "#/definitions/input"
                 },
                 "configRef": {
-                    "type": "string"
+                    "$ref": "#/definitions/configRef"
                 },
                 "value": {
                     "$ref": "#/definitions/staticVariableValue"
@@ -70,26 +79,14 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "input": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "step": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "step",
-                        "name"
-                    ]
+                    "$ref": "#/definitions/input"
                 },
                 "configRef": {
-                    "type": "string"
+                    "$ref": "#/definitions/configRef"
                 },
                 "value": {
                     "$ref": "#/definitions/staticVariableValue"
@@ -125,10 +122,12 @@
             "type": "string"
         },
         "serviceGroup": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "rolloutName": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "resourceGroups": {
             "type": "array",
@@ -137,10 +136,12 @@
                 "additionalProperties": false,
                 "properties": {
                     "name": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     },
                     "subscription": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     },
                     "subscriptionProvisioning": {
                         "type": "object",
@@ -156,7 +157,8 @@
                                 "$ref": "#/definitions/value"
                             },
                             "roleAssignment": {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             }
                         },
                         "required": [
@@ -586,7 +588,7 @@
                                             "const": "ProviderFeatureRegistration"
                                         },
                                         "providerConfigRef" : {
-                                            "type": "string"
+                                            "$ref": "#/definitions/configRef"
                                         },
                                         "identityFrom" : {
                                             "$ref": "#/definitions/input"
@@ -613,13 +615,16 @@
                                             "const": "SecretSync"
                                         },
                                         "configurationFile" : {
-                                            "type": "string"
+                                            "type": "string",
+                                            "minLength": 1
                                         },
                                         "encryptionKey" : {
-                                            "type": "string"
+                                            "type": "string",
+                                            "minLength": 1
                                         },
                                         "keyVault" : {
-                                            "type": "string"
+                                            "type": "string",
+                                            "minLength": 1
                                         },
                                         "identityFrom" : {
                                             "$ref": "#/definitions/input"
@@ -627,7 +632,8 @@
                                         "dependsOn": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "minLength": 1
                                             }
                                         }
                                     },

--- a/pkg/types/util.go
+++ b/pkg/types/util.go
@@ -70,15 +70,6 @@ func ValidatePipelineSchema(pipelineContent []byte) error {
 	return nil
 }
 
-func ValidatePipelineSchemaForStruct(pipeline *Pipeline) error {
-	pipelineBytes, err := yaml.Marshal(pipeline)
-	if err != nil {
-		return fmt.Errorf("failed to marshal pipeline: %w", err)
-	}
-
-	return ValidatePipelineSchema(pipelineBytes)
-}
-
 func compileSchema(schemaRef string, schemaBytes []byte) (*jsonschema.Schema, error) {
 	// parse schema content
 	schemaMap := make(map[string]interface{})

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -10,11 +10,11 @@ resourceGroups:
   subscription: '{{ .svc.subscription.key }}'
   subscriptionProvisioning:
     displayName:
-      configRef: .svc.subscription.displayName
+      configRef: svc.subscription.displayName
     airsRegisteredUserPrincipalId:
-      configRef: .svc.subscription.airsRegisteredUserPrincipalId
+      configRef: svc.subscription.airsRegisteredUserPrincipalId
     certificateDomains:
-      configRef: .svc.subscription.certificateDomains
+      configRef: svc.subscription.certificateDomains
     roleAssignment: 'test.bicepparam'
   steps:
   - name: deploy
@@ -193,7 +193,7 @@ resourceGroups:
   subscription: '{{ .managementClusterSubscription }}'
   subscriptionProvisioning:
     displayName:
-      configRef: .svc.subscription.displayName
+      configRef: svc.subscription.displayName
     roleAssignment: 'test.bicepparam'
   steps:
     - name: register-providers-afec-flags

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -182,11 +182,11 @@ resourceGroups:
   subscription: hcp-int-svc-uksouth
   subscriptionProvisioning:
     airsRegisteredUserPrincipalId:
-      configRef: .svc.subscription.airsRegisteredUserPrincipalId
+      configRef: svc.subscription.airsRegisteredUserPrincipalId
     certificateDomains:
-      configRef: .svc.subscription.certificateDomains
+      configRef: svc.subscription.certificateDomains
     displayName:
-      configRef: .svc.subscription.displayName
+      configRef: svc.subscription.displayName
     roleAssignment: test.bicepparam
 - name: global
   steps:
@@ -223,7 +223,7 @@ resourceGroups:
   subscription: hcp-uksouth
   subscriptionProvisioning:
     displayName:
-      configRef: .svc.subscription.displayName
+      configRef: svc.subscription.displayName
     roleAssignment: test.bicepparam
 rolloutName: Test Rollout
 serviceGroup: Microsoft.Azure.ARO.Test


### PR DESCRIPTION
Before, we would round-trip the user's input through the types before applying the schema to it for validation. This meant we would have loads of weird edge cases like:

- a user provides an invalid field to a step
- the unmarshal ignores it, since it's not known
- the field is gone by the time we marshal, schema validation passes

Or:

- a user forgets a required field (and the requirement has no minimum length set)
- unmarshal is OK with it, defaults to the zero-value in Go
- marshal commits the zero-value to the output
- schema validation passes

This commit runs validation directly on user input, so we can't have these issues. We also tighten up some schema rules to make validations nicer.