### PR TITLE
pipeline: add a Ev2 registration step

### DIFF
--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -148,6 +148,15 @@ func (s *ProviderFeatureRegistrationStep) Description() string {
 	return fmt.Sprintf("Step %s\n Kind: %s\n", s.Name, s.Action)
 }
 
+type Ev2RegistrationStep struct {
+	StepMeta     `json:",inline"`
+	IdentityFrom Input `json:"identityFrom,omitempty"`
+}
+
+func (s *Ev2RegistrationStep) Description() string {
+	return fmt.Sprintf("Step %s\n Kind: %s\n", s.Name, s.Action)
+}
+
 type SecretSyncStep struct {
 	StepMeta          `json:",inline"`
 	ConfigurationFile string `json:"configurationFile,omitempty"`

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -642,6 +642,30 @@
                                         "keyVault",
                                         "identityFrom"
                                     ]
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "action": {
+                                            "const": "Ev2Registration"
+                                        },
+                                        "identityFrom" : {
+                                            "$ref": "#/definitions/input"
+                                        },
+                                        "dependsOn": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "identityFrom"
+                                    ]
                                 }
                             ],
                             "required": [

--- a/pkg/types/resourcegroup.go
+++ b/pkg/types/resourcegroup.go
@@ -78,6 +78,8 @@ func (s *Steps) UnmarshalJSON(data []byte) error {
 			step = &FeatureRegistrationStep{}
 		case "ProviderFeatureRegistration":
 			step = &ProviderFeatureRegistrationStep{}
+		case "Ev2Registration":
+			step = &Ev2RegistrationStep{}
 		case "SecretSync":
 			step = &SecretSyncStep{}
 		default:

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -202,6 +202,11 @@ resourceGroups:
         step: deploy
         name: whatever
       providerConfigRef: svc.subscription.displayName
+    - name: register-ev2-services
+      action: Ev2Registration
+      identityFrom:
+        step: deploy
+        name: whatever
     - name: sync-secrets
       action: SecretSync
       keyVault: '{{ .global.keyVault.name }}'

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -196,6 +196,11 @@ resourceGroups:
       step: deploy
     name: register-providers-afec-flags
     providerConfigRef: svc.subscription.displayName
+  - action: Ev2Registration
+    identityFrom:
+      name: whatever
+      step: deploy
+    name: register-ev2-services
   - action: SecretSync
     configurationFile: data/encryptedsecrets/config.yaml
     encryptionKey: secretSyncKey


### PR DESCRIPTION
We ideally would not need to do this, but it's the simplest way to get the values we need passed in.