### PR TITLE
secret-sync fix check for existing KV in config

### DIFF
--- a/pkg/secret-sync/register/options.go
+++ b/pkg/secret-sync/register/options.go
@@ -115,15 +115,6 @@ func (o *ValidatedOptions) Complete() (*Options, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	keyVaultCfg, exists := cfg.KeyVaults[o.KeyVault]
-	if !exists && o.PublicKeyFile == "" {
-		return nil, fmt.Errorf("keyvault %s does not exist in encryption config and no public key file specified to bootstrap it", o.KeyVault)
-	}
-
-	if keyVaultCfg.KeyEncryptionKey == "" && o.PublicKeyFile == "" {
-		return nil, fmt.Errorf("no public key recorded for key vault in encryption config and no public key file specified")
-	}
-
 	rawSecret, err := os.ReadFile(o.SecretFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read secret file %s: %w", o.SecretFile, err)
@@ -155,6 +146,15 @@ func (o *ValidatedOptions) Complete() (*Options, error) {
 	}
 
 	keyVaultURI := fmt.Sprintf("https://%s.%s", o.KeyVault, keyVaultDNSSuffix)
+
+	keyVaultCfg, exists := cfg.KeyVaults[keyVaultURI]
+	if !exists && o.PublicKeyFile == "" {
+		return nil, fmt.Errorf("keyvault %s does not exist in encryption config and no public key file specified to bootstrap it", o.KeyVault)
+	}
+
+	if keyVaultCfg.KeyEncryptionKey == "" && o.PublicKeyFile == "" {
+		return nil, fmt.Errorf("no public key recorded for key vault in encryption config and no public key file specified")
+	}
 
 	return &Options{
 		completedOptions: &completedOptions{


### PR DESCRIPTION
the `register` command offers an option to register new secrets with the encrypted secrets file without the need to respecify the public key for a KV that is already tracked. there was a bug in detecting if a KV is already tracked though, looking with the KV name instead of the KV URI.