### PR TITLE
pkg/types: correctly enforce step name uniqueness, refer to rgs

### DIFF
--- a/pkg/types/arm.go
+++ b/pkg/types/arm.go
@@ -55,7 +55,7 @@ func NewARMStep(name string, template string, parameters string, deploymentLevel
 }
 
 // WithDependsOn fluent method that sets DependsOn
-func (s *ARMStep) WithDependsOn(dependsOn ...string) *ARMStep {
+func (s *ARMStep) WithDependsOn(dependsOn ...StepDependency) *ARMStep {
 	s.DependsOn = dependsOn
 	return s
 }
@@ -80,4 +80,14 @@ func (s *ARMStep) Description() string {
 	details = append(details, fmt.Sprintf("Template: %s", s.Template))
 	details = append(details, fmt.Sprintf("Parameters: %s", s.Parameters))
 	return fmt.Sprintf("Step %s\n  Kind: %s\n  %s", s.Name, s.Action, strings.Join(details, "\n  "))
+}
+
+func (s *ARMStep) RequiredInputs() []StepDependency {
+	var deps []StepDependency
+	for _, val := range s.Variables {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
+	return deps
 }

--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -41,6 +41,16 @@ func (s *ImageMirrorStep) Description() string {
 	return fmt.Sprintf("Step %s\n  Kind: %s\n  From %v:%v@%v to %v\n", s.Name, s.Action, s.SourceRegistry, s.Repository, s.Digest, s.TargetACR)
 }
 
+func (s *ImageMirrorStep) RequiredInputs() []StepDependency {
+	var deps []StepDependency
+	for _, val := range []Value{s.TargetACR, s.SourceRegistry, s.Repository, s.Digest, s.PullSecretKeyVault, s.PullSecretName, s.ShellIdentity} {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
+	return deps
+}
+
 // ResolveImageMirrorStep resolves an image mirror step to a shell step. It's up to the user to write the contents of
 // the OnDemandSyncScript to disk somewhere and pass the file name in as a parameter here, as we likely don't want to
 // inline 100+ lines of shell into a `bash -C "<contents>"` call and hope all the string interpolations work.

--- a/pkg/types/imagemirror_test.go
+++ b/pkg/types/imagemirror_test.go
@@ -49,7 +49,7 @@ func TestResolveImageMirrorStep(t *testing.T) {
 				StepMeta: StepMeta{
 					Name:      "image-mirror-step",
 					Action:    "ImageMirror",
-					DependsOn: []string{"previous-step"},
+					DependsOn: []StepDependency{{ResourceGroup: "whatever", Step: "previous-step"}},
 				},
 				TargetACR:          Value{Value: "myacr.azurecr.io"},
 				SourceRegistry:     Value{Value: "docker.io"},

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -4,6 +4,26 @@
   "type": "object",
   "additionalProperties": false,
   "definitions": {
+    "stepReference": {
+      "type": "object",
+      "properties": {
+        "resourceGroup": {
+          "type": "string",
+          "minLength": 1
+        },
+        "step": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "stepDependencies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/stepReference"
+      },
+      "minLength": 1
+    },
     "configRef": {
       "type": "string",
       "minLength": 1,
@@ -28,6 +48,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "resourceGroup": {
+          "type": "string",
+          "minLength": 1
+        },
         "step": {
           "type": "string",
           "minLength": 1
@@ -139,6 +163,10 @@
             "type": "string",
             "minLength": 1
           },
+          "resourceGroup": {
+            "type": "string",
+            "minLength": 1
+          },
           "subscription": {
             "type": "string",
             "minLength": 1
@@ -196,10 +224,7 @@
                       }
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/definitions/stepDependencies"
                     },
                     "deploymentLevel": {
                       "type": "string",
@@ -253,10 +278,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     },
                     "dryRun": {
                       "type": "object",
@@ -294,10 +316,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -330,10 +349,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -378,10 +394,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -408,10 +421,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -443,10 +453,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -476,10 +483,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -510,10 +514,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -587,10 +588,7 @@
                       "additionalProperties": false
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -641,10 +639,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -676,10 +671,7 @@
                       "$ref": "#/definitions/value"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -704,10 +696,7 @@
                       "$ref": "#/definitions/input"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref":  "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -740,11 +729,7 @@
                       "$ref": "#/definitions/input"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      }
+                      "$ref": "#/definitions/stepDependencies"
                     }
                   },
                   "required": [
@@ -767,11 +752,7 @@
                       "$ref": "#/definitions/input"
                     },
                     "dependsOn": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      }
+                      "$ref": "#/definitions/stepDependencies"
                     }
                   },
                   "required": [

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -1,818 +1,821 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "pipeline.schema.v1",
-    "type": "object",
-    "additionalProperties": false,
-    "definitions": {
-        "configRef": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "pipeline.schema.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "configRef": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*"
+    },
+    "staticVariableValue": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
             "type": "string",
-            "minLength": 1,
-            "pattern": "[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*"
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "step": {
+          "type": "string",
+          "minLength": 1
         },
-        "staticVariableValue": {
-            "oneOf": [
-                {
-                    "type": "string",
-                    "minLength": 1
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1
-                    }
-                }
-            ]
-        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "step",
+        "name"
+      ]
+    },
+    "value": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
         "input": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "step": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "name": {
-                    "type": "string",
-                    "minLength": 1
-                }
-            },
-            "required": [
-                "step",
-                "name"
-            ]
+          "$ref": "#/definitions/input"
+        },
+        "configRef": {
+          "$ref": "#/definitions/configRef"
         },
         "value": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "input": {
-                    "$ref": "#/definitions/input"
-                },
-                "configRef": {
-                    "$ref": "#/definitions/configRef"
-                },
-                "value": {
-                    "$ref": "#/definitions/staticVariableValue"
-                }
-            },
-            "oneOf": [
-                {
-                    "required": [
-                        "input"
-                    ]
-                },
-                {
-                    "required": [
-                        "configRef"
-                    ]
-                },
-                {
-                    "required": [
-                        "value"
-                    ]
-                }
-            ]
-        },
-        "variable": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "input": {
-                    "$ref": "#/definitions/input"
-                },
-                "configRef": {
-                    "$ref": "#/definitions/configRef"
-                },
-                "value": {
-                    "$ref": "#/definitions/staticVariableValue"
-                }
-            },
-            "oneOf": [
-                {
-                    "required": [
-                        "name",
-                        "input"
-                    ]
-                },
-                {
-                    "required": [
-                        "name",
-                        "configRef"
-                    ]
-                },
-                {
-                    "required": [
-                        "name",
-                        "value"
-                    ]
-                }
-            ],
-            "required": [
-                "name"
-            ]
+          "$ref": "#/definitions/staticVariableValue"
         }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "input"
+          ]
+        },
+        {
+          "required": [
+            "configRef"
+          ]
+        },
+        {
+          "required": [
+            "value"
+          ]
+        }
+      ]
     },
-    "properties": {
-        "$schema": {
-            "type": "string"
+    "variable": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
         },
-        "serviceGroup": {
+        "input": {
+          "$ref": "#/definitions/input"
+        },
+        "configRef": {
+          "$ref": "#/definitions/configRef"
+        },
+        "value": {
+          "$ref": "#/definitions/staticVariableValue"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "name",
+            "input"
+          ]
+        },
+        {
+          "required": [
+            "name",
+            "configRef"
+          ]
+        },
+        {
+          "required": [
+            "name",
+            "value"
+          ]
+        }
+      ],
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "serviceGroup": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rolloutName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resourceGroups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
             "type": "string",
             "minLength": 1
-        },
-        "rolloutName": {
+          },
+          "subscription": {
             "type": "string",
             "minLength": 1
-        },
-        "resourceGroups": {
+          },
+          "subscriptionProvisioning": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "displayName": {
+                "$ref": "#/definitions/value"
+              },
+              "airsRegisteredUserPrincipalId": {
+                "$ref": "#/definitions/value"
+              },
+              "certificateDomains": {
+                "$ref": "#/definitions/value"
+              },
+              "backfillSubscriptionId": {
+                "$ref": "#/definitions/value"
+              },
+              "roleAssignment": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "displayName",
+              "roleAssignment"
+            ]
+          },
+          "steps": {
             "type": "array",
             "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
                     "name": {
-                        "type": "string",
-                        "minLength": 1
+                      "type": "string"
                     },
-                    "subscription": {
-                        "type": "string",
-                        "minLength": 1
+                    "action": {
+                      "const": "ARM"
                     },
-                    "subscriptionProvisioning": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "displayName": {
-                                "$ref": "#/definitions/value"
-                            },
-                            "airsRegisteredUserPrincipalId": {
-                                "$ref": "#/definitions/value"
-                            },
-                            "certificateDomains": {
-                                "$ref": "#/definitions/value"
-                            },
-                            "backfillSubscriptionId": {
-                                "$ref": "#/definitions/value"
-                            },
-                            "roleAssignment": {
-                                "type": "string",
-                                "minLength": 1
-                            }
-                        },
-                        "required": [
-                            "displayName",
-                            "roleAssignment"
-                        ]
+                    "template": {
+                      "type": "string"
                     },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "oneOf": [
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "ARM"
-                                        },
-                                        "template": {
-                                            "type": "string"
-                                        },
-                                        "parameters": {
-                                            "type": "string"
-                                        },
-                                        "variables": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/definitions/variable"
-                                            }
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "deploymentLevel": {
-                                            "type": "string",
-                                            "enum": [
-                                                "ResourceGroup",
-                                                "Subscription"
-                                            ]
-                                        },
-                                        "deploymentMode": {
-                                            "type": "string",
-                                            "enum": [
-                                                "incremental",
-                                                "complete"
-                                            ]
-                                        },
-                                        "outputOnly": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "template",
-                                        "parameters",
-                                        "deploymentLevel"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "Shell"
-                                        },
-                                        "command": {
-                                            "type": "string"
-                                        },
-                                        "aksCluster": {
-                                            "type": "string"
-                                        },
-                                        "variables": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/definitions/variable"
-                                            }
-                                        },
-                                        "subnetName": {
-                                            "type": "string"
-                                        },
-                                        "shellIdentity": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "dryRun": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "command": {
-                                                    "type": "string"
-                                                },
-                                                "variables": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/definitions/variable"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "command"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "DelegateChildZone"
-                                        },
-                                        "parentZone": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "childZone": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "parentZone",
-                                        "childZone"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "SetCertificateIssuer"
-                                        },
-                                        "vaultBaseUrl": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "issuer": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "applicationId": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "vaultBaseUrl",
-                                        "issuer",
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "applicationId"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "CreateCertificate"
-                                        },
-                                        "vaultBaseUrl": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "certificateName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "contentType": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "san": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "issuer": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "applicationId": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "vaultBaseUrl",
-                                        "certificateName",
-                                        "contentType",
-                                        "san",
-                                        "issuer",
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "applicationId"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "ResourceProviderRegistration"
-                                        },
-                                        "resourceProviderNamespaces": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "resourceProviderNamespaces"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "Kusto"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },                                    
-                                        "applicationId": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "connectionString": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "command": {
-                                            "$ref": "#/definitions/value"
-                                        },                                                                                                                                                             
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "applicationId",
-                                        "connectionString",
-                                        "command"
-                                    ]
-                                },    
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "Pav2ManageAppId"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },                                    
-                                        "smeAppidParameter": {
-                                            "$ref": "#/definitions/value"
-                                        },                                                                                                                                                       
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "smeAppidParameter"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "Pav2AddAccount"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "storageAccount": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "smeEndpointSuffixParameter": {
-                                            "$ref": "#/definitions/value"
-                                        },                                                                                                                                                    
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "storageAccount",
-                                        "smeEndpointSuffixParameter"
-                                    ]
-                                },                                                             
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "type": "string",
-                                            "enum": ["RPLogsAccount", "ClusterLogsAccount"]
-                                        },
-                                        "typeName":  {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "environment":  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "accountName":  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "metricsAccount":  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "adminAlias":  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "adminGroup":  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "subscriptionId": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "namespace": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "certsan": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "certdescription": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "configVersion": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "events": {
-                                            "type": "object",
-                                            "description": "A map of event configurations where keys represent the fluent bit tag and values are their corresponding Geneva table name. Refer to https://eng.ms/docs/products/geneva/collect/instrument/linux/fluentd for details",
-                                            "patternProperties": {
-                                                "^.*$": {
-                                                    "type": "string",
-                                                    "description": "Geneva table name for the corresponding fluent bit tag"
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "typeName",
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "environment",
-                                        "accountName",
-                                        "metricsAccount",
-                                        "adminAlias",
-                                        "adminGroup",
-                                        "subscriptionId",
-                                        "namespace",
-                                        "certsan",
-                                        "certdescription",
-                                        "configVersion",
-                                        "events"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "ImageMirror"
-                                        },
-                                        "targetACR" : {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "sourceRegistry" : {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "repository" :  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "digest" : {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "pullSecretKeyVault" :  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "pullSecretName" : {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "shellIdentity" :  {
-                                            "$ref":  "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "targetACR",
-                                        "sourceRegistry",
-                                        "repository",
-                                        "digest",
-                                        "pullSecretKeyVault",
-                                        "pullSecretName",
-                                        "shellIdentity"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "FeatureRegistration"
-                                        },
-                                        "featureFlags" : {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretKeyVault": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "secretName": {
-                                            "$ref": "#/definitions/value"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "secretKeyVault",
-                                        "secretName",
-                                        "featureFlags"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "ProviderFeatureRegistration"
-                                        },
-                                        "providerConfigRef" : {
-                                            "$ref": "#/definitions/configRef"
-                                        },
-                                        "identityFrom" : {
-                                            "$ref": "#/definitions/input"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "providerConfigRef",
-                                        "identityFrom"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "SecretSync"
-                                        },
-                                        "configurationFile" : {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        "encryptionKey" : {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        "keyVault" : {
-                                            "type": "string",
-                                            "minLength": 1
-                                        },
-                                        "identityFrom" : {
-                                            "$ref": "#/definitions/input"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "configurationFile",
-                                        "encryptionKey",
-                                        "keyVault",
-                                        "identityFrom"
-                                    ]
-                                },
-                                {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "action": {
-                                            "const": "Ev2Registration"
-                                        },
-                                        "identityFrom" : {
-                                            "$ref": "#/definitions/input"
-                                        },
-                                        "dependsOn": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "identityFrom"
-                                    ]
-                                }
-                            ],
-                            "required": [
-                                "name",
-                                "action"
-                            ]
-                        }
+                    "parameters": {
+                      "type": "string"
+                    },
+                    "variables": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/variable"
+                      }
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deploymentLevel": {
+                      "type": "string",
+                      "enum": [
+                        "ResourceGroup",
+                        "Subscription"
+                      ]
+                    },
+                    "deploymentMode": {
+                      "type": "string",
+                      "enum": [
+                        "incremental",
+                        "complete"
+                      ]
+                    },
+                    "outputOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "template",
+                    "parameters",
+                    "deploymentLevel"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "Shell"
+                    },
+                    "command": {
+                      "type": "string"
                     },
                     "aksCluster": {
-                        "description": "Deprecated, to be removed",
+                      "type": "string"
+                    },
+                    "variables": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/variable"
+                      }
+                    },
+                    "subnetName": {
+                      "type": "string"
+                    },
+                    "shellIdentity": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
                         "type": "string"
+                      }
+                    },
+                    "dryRun": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "string"
+                        },
+                        "variables": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/variable"
+                          }
+                        }
+                      }
                     }
+                  },
+                  "required": [
+                    "command"
+                  ]
                 },
-                "required": [
-                    "name",
-                    "subscription",
-                    "steps"
-                ]
-            }
-        },
-        "buildStep": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "command": {
-                    "type": "string"
-                },
-                "args": {
-                    "type": "array",
-                    "items": {
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "DelegateChildZone"
+                    },
+                    "parentZone": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "childZone": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
                         "type": "string"
+                      }
                     }
+                  },
+                  "required": [
+                    "parentZone",
+                    "childZone"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "SetCertificateIssuer"
+                    },
+                    "vaultBaseUrl": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "issuer": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "applicationId": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "vaultBaseUrl",
+                    "issuer",
+                    "secretKeyVault",
+                    "secretName",
+                    "applicationId"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "CreateCertificate"
+                    },
+                    "vaultBaseUrl": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "certificateName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "contentType": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "san": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "issuer": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "applicationId": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "vaultBaseUrl",
+                    "certificateName",
+                    "contentType",
+                    "san",
+                    "issuer",
+                    "secretKeyVault",
+                    "secretName",
+                    "applicationId"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "ResourceProviderRegistration"
+                    },
+                    "resourceProviderNamespaces": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "resourceProviderNamespaces"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "Kusto"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "applicationId": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "connectionString": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "command": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "secretKeyVault",
+                    "secretName",
+                    "applicationId",
+                    "connectionString",
+                    "command"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "Pav2ManageAppId"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "smeAppidParameter": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "secretKeyVault",
+                    "secretName",
+                    "smeAppidParameter"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "Pav2AddAccount"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "storageAccount": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "smeEndpointSuffixParameter": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "secretKeyVault",
+                    "secretName",
+                    "storageAccount",
+                    "smeEndpointSuffixParameter"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string",
+                      "enum": [
+                        "RPLogsAccount",
+                        "ClusterLogsAccount"
+                      ]
+                    },
+                    "typeName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "environment": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "accountName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "metricsAccount": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "adminAlias": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "adminGroup": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "subscriptionId": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "namespace": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "certsan": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "certdescription": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "configVersion": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "events": {
+                      "type": "object",
+                      "description": "A map of event configurations where keys represent the fluent bit tag and values are their corresponding Geneva table name. Refer to https://eng.ms/docs/products/geneva/collect/instrument/linux/fluentd for details",
+                      "patternProperties": {
+                        "^.*$": {
+                          "type": "string",
+                          "description": "Geneva table name for the corresponding fluent bit tag"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "typeName",
+                    "secretKeyVault",
+                    "secretName",
+                    "environment",
+                    "accountName",
+                    "metricsAccount",
+                    "adminAlias",
+                    "adminGroup",
+                    "subscriptionId",
+                    "namespace",
+                    "certsan",
+                    "certdescription",
+                    "configVersion",
+                    "events"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "ImageMirror"
+                    },
+                    "targetACR": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "sourceRegistry": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "repository": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "digest": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "pullSecretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "pullSecretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "shellIdentity": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "targetACR",
+                    "sourceRegistry",
+                    "repository",
+                    "digest",
+                    "pullSecretKeyVault",
+                    "pullSecretName",
+                    "shellIdentity"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "FeatureRegistration"
+                    },
+                    "featureFlags": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretKeyVault": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "secretName": {
+                      "$ref": "#/definitions/value"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "secretKeyVault",
+                    "secretName",
+                    "featureFlags"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "ProviderFeatureRegistration"
+                    },
+                    "providerConfigRef": {
+                      "$ref": "#/definitions/configRef"
+                    },
+                    "identityFrom": {
+                      "$ref": "#/definitions/input"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "providerConfigRef",
+                    "identityFrom"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "SecretSync"
+                    },
+                    "configurationFile": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "encryptionKey": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "keyVault": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "identityFrom": {
+                      "$ref": "#/definitions/input"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "required": [
+                    "configurationFile",
+                    "encryptionKey",
+                    "keyVault",
+                    "identityFrom"
+                  ]
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "const": "Ev2Registration"
+                    },
+                    "identityFrom": {
+                      "$ref": "#/definitions/input"
+                    },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "required": [
+                    "identityFrom"
+                  ]
                 }
+              ],
+              "required": [
+                "name",
+                "action"
+              ]
             }
-        }
+          },
+          "aksCluster": {
+            "description": "Deprecated, to be removed",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "subscription",
+          "steps"
+        ]
+      }
     },
-    "required": [
-        "serviceGroup",
-        "rolloutName",
-        "resourceGroups"
-    ]
+    "buildStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "serviceGroup",
+    "rolloutName",
+    "resourceGroups"
+  ]
 }

--- a/pkg/types/resourcegroup.go
+++ b/pkg/types/resourcegroup.go
@@ -24,6 +24,7 @@ import (
 // ResourceGroup represents the resourcegroup containing all steps
 type ResourceGroup struct {
 	Name                     string                    `json:"name"`
+	ResourceGroup            string                    `json:"resourceGroup"`
 	Subscription             string                    `json:"subscription"`
 	SubscriptionProvisioning *SubscriptionProvisioning `json:"subscriptionProvisioning,omitempty"`
 	// Deprecated: AKSCluster to be removed

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -63,6 +63,19 @@ func (s *ShellStep) Description() string {
 	return fmt.Sprintf("Step %s\n  Kind: %s\n  Command: %s\n", s.Name, s.Action, s.Command)
 }
 
+func (s *ShellStep) RequiredInputs() []StepDependency {
+	var deps []StepDependency
+	for _, val := range append(s.Variables, s.DryRun.Variables...) {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
+	if s.ShellIdentity.Input != nil {
+		deps = append(deps, s.ShellIdentity.Input.StepDependency)
+	}
+	return deps
+}
+
 // WithAKSCluster fluent method that sets AKSCluster
 func (s *ShellStep) WithAKSCluster(aksCluster string) *ShellStep {
 	s.AKSCluster = aksCluster
@@ -70,7 +83,7 @@ func (s *ShellStep) WithAKSCluster(aksCluster string) *ShellStep {
 }
 
 // WithDependsOn fluent method that sets DependsOn
-func (s *ShellStep) WithDependsOn(dependsOn ...string) *ShellStep {
+func (s *ShellStep) WithDependsOn(dependsOn ...StepDependency) *ShellStep {
 	s.DependsOn = dependsOn
 	return s
 }

--- a/pkg/types/variables.go
+++ b/pkg/types/variables.go
@@ -51,10 +51,10 @@ func (v *Value) String() string {
 	return "unknown"
 }
 
-// Input
-// Holds the values used for output chaining:
-//   - Step: Referenced step
+// Input describes a variable that some other step produces, which we consume.
 type Input struct {
+	// StepDependency declares from which step we are consuming the output variable.
+	StepDependency `json:",inline"`
+	// Name is the output variable we consume for input chaining.
 	Name string `json:"name"`
-	Step string `json:"step"`
 }

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -6,7 +6,8 @@ buildStep:
   args:
     - build
 resourceGroups:
-- name: '{{ .regionRG  }}'
+- name: regional
+  resourceGroup: '{{ .regionRG  }}'
   subscription: '{{ .svc.subscription.key }}'
   subscriptionProvisioning:
     displayName:
@@ -48,6 +49,7 @@ resourceGroups:
     variables:
       - name: MAESTRO_IMAGE
         input:
+          resourceGroup: regional
           step: deploy
           name: whatever
   - name: cxChildZone
@@ -57,7 +59,8 @@ resourceGroups:
     childZone:
       configRef: childZone
     dependsOn:
-    - deploy
+    - step: deploy
+      resourceGroup: regional
   - name: issuerTest
     action: SetCertificateIssuer
     secretKeyVault:
@@ -71,7 +74,8 @@ resourceGroups:
     issuer:
       configRef: provider
     dependsOn:
-    - deploy
+    - step: deploy
+      resourceGroup: regional
   - name: issuerTestOutputChaining
     action: SetCertificateIssuer
     secretKeyVault:
@@ -82,12 +86,14 @@ resourceGroups:
       configRef: ev2.assistedId.applicationId
     vaultBaseUrl:
       input:
+        resourceGroup: regional
         name: kvUrl
         step: deploy
     issuer:
       value: provider
     dependsOn:
-    - deploy
+    - step: deploy
+      resourceGroup: regional
   - name: cert
     action: CreateCertificate
     secretKeyVault:
@@ -189,7 +195,8 @@ resourceGroups:
       value: pullSecretName
     shellIdentity:
       value: shellIdentity
-- name: '{{ .globalRG  }}'
+- name: global
+  resourceGroup: '{{ .globalRG  }}'
   subscription: '{{ .managementClusterSubscription }}'
   subscriptionProvisioning:
     displayName:
@@ -199,12 +206,14 @@ resourceGroups:
     - name: register-providers-afec-flags
       action: ProviderFeatureRegistration
       identityFrom:
+        resourceGroup: regional
         step: deploy
         name: whatever
       providerConfigRef: svc.subscription.displayName
     - name: register-ev2-services
       action: Ev2Registration
       identityFrom:
+        resourceGroup: regional
         step: deploy
         name: whatever
     - name: sync-secrets
@@ -213,9 +222,10 @@ resourceGroups:
       configurationFile: 'data/encryptedsecrets/config.yaml'
       encryptionKey: 'secretSyncKey'
       identityFrom:
+        resourceGroup: regional
         step: deploy
         name: whatever
-    - name: image-mirror-ii
+    - name: image-mirror
       action: ImageMirror
       targetACR:
         value: targetACR
@@ -249,5 +259,6 @@ resourceGroups:
         configRef: ev2.assistedId.certificate.name
       smeAppidParameter:
         input:
+          resourceGroup: regional
           name: kvUrl
           step: deploy   

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -4,7 +4,8 @@ buildStep:
   - build
   command: make
 resourceGroups:
-- name: hcp-underlay-uks
+- name: regional
+  resourceGroup: hcp-underlay-uks
   steps:
   - action: Shell
     aksCluster: aro-hcp-aks
@@ -38,13 +39,15 @@ resourceGroups:
     variables:
     - input:
         name: whatever
+        resourceGroup: regional
         step: deploy
       name: MAESTRO_IMAGE
   - action: DelegateChildZone
     childZone:
       configRef: childZone
     dependsOn:
-    - deploy
+    - resourceGroup: regional
+      step: deploy
     name: cxChildZone
     parentZone:
       configRef: parentZone
@@ -52,7 +55,8 @@ resourceGroups:
     applicationId:
       configRef: ev2.assistedId.applicationId
     dependsOn:
-    - deploy
+    - resourceGroup: regional
+      step: deploy
     issuer:
       configRef: provider
     name: issuerTest
@@ -66,7 +70,8 @@ resourceGroups:
     applicationId:
       configRef: ev2.assistedId.applicationId
     dependsOn:
-    - deploy
+    - resourceGroup: regional
+      step: deploy
     issuer:
       value: provider
     name: issuerTestOutputChaining
@@ -77,6 +82,7 @@ resourceGroups:
     vaultBaseUrl:
       input:
         name: kvUrl
+        resourceGroup: regional
         step: deploy
   - action: CreateCertificate
     applicationId:
@@ -189,16 +195,19 @@ resourceGroups:
       configRef: svc.subscription.displayName
     roleAssignment: test.bicepparam
 - name: global
+  resourceGroup: global
   steps:
   - action: ProviderFeatureRegistration
     identityFrom:
       name: whatever
+      resourceGroup: regional
       step: deploy
     name: register-providers-afec-flags
     providerConfigRef: svc.subscription.displayName
   - action: Ev2Registration
     identityFrom:
       name: whatever
+      resourceGroup: regional
       step: deploy
     name: register-ev2-services
   - action: SecretSync
@@ -206,13 +215,14 @@ resourceGroups:
     encryptionKey: secretSyncKey
     identityFrom:
       name: whatever
+      resourceGroup: regional
       step: deploy
     keyVault: arohcpint-global
     name: sync-secrets
   - action: ImageMirror
     digest:
       value: digest
-    name: image-mirror-ii
+    name: image-mirror
     pullSecretKeyVault:
       value: pullSecretKeyVault
     pullSecretName:
@@ -244,6 +254,7 @@ resourceGroups:
     smeAppidParameter:
       input:
         name: kvUrl
+        resourceGroup: regional
         step: deploy
   subscription: hcp-uksouth
   subscriptionProvisioning:

--- a/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_deps.yaml
+++ b/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_deps.yaml
@@ -1,7 +1,8 @@
 action: Shell
 command: /bin/bash /path/to/script.sh
 dependsOn:
-- previous-step
+- resourceGroup: whatever
+  step: previous-step
 dryRun:
   variables:
   - name: DRY_RUN


### PR DESCRIPTION
schema: apply formatting

This file has not had coherent formatting, which makes diffs annoying to
read. We should likely just store it as YAML and run yamlfmt on this
repo, but this editor-applied formatting will suffice for now.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

pkg/types: correctly enforce step name uniqueness, refer to rgs

In the infancy of this tooling, the perplexing choice was made to
require step names to be unique across the entire pipeline. There is no
such requirement; steps must only be unique within the resource group.

Similarly, we chose not to expose the name of the resource group (the
semantic identifier for the pipeline, not the literal name of the Azure
resource group object).

This commit requires resource groups to have identifiers and requires
references to steps to qualify both the resource group and the step name
to which they refer.

This change is required to allow us to make build-out pipelines that run
more than one pipelines' worth of steps.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

