### PR TITLE
pkg/types: make validation stricter

### DIFF
--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -15,7 +15,11 @@
           "type": "string",
           "minLength": 1
         }
-      }
+      },
+      "required": [
+        "resourceGroup",
+        "step"
+      ]
     },
     "stepDependencies": {
       "type": "array",
@@ -62,6 +66,7 @@
         }
       },
       "required": [
+        "resourceGroup",
         "step",
         "name"
       ]
@@ -773,6 +778,7 @@
         },
         "required": [
           "name",
+          "resourceGroup",
           "subscription",
           "steps"
         ]

--- a/pkg/types/validation_test.go
+++ b/pkg/types/validation_test.go
@@ -229,8 +229,9 @@ func TestValidatePipelineSchema(t *testing.T) {
 				"rolloutName":  "test",
 				"resourceGroups": []interface{}{
 					map[string]interface{}{
-						"name":         "rg",
-						"subscription": "sub",
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
 						"steps": []interface{}{
 							map[string]interface{}{
 								"name":    "step",
@@ -249,9 +250,10 @@ func TestValidatePipelineSchema(t *testing.T) {
 				"rolloutName":  "test",
 				"resourceGroups": []interface{}{
 					map[string]interface{}{
-						"name":         "rg",
-						"subscription": "sub",
-						"aksCluster":   "aks",
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
+						"aksCluster":    "aks",
 						"steps": []interface{}{
 							map[string]interface{}{
 								"name":   "step",


### PR DESCRIPTION
`minLength` without `required` means you are free to entirely omit the field, but if you provide it, it must be non-zero length ...