### PR TITLE
pkg/types: expose execution constraints

### DIFF
--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -144,6 +144,46 @@
       "required": [
         "name"
       ]
+    },
+    "executionConstraint": {
+      "type": "object",
+      "properties": {
+        "singleton": {
+          "type": "boolean"
+        },
+        "clouds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "public",
+              "ff",
+              "mc",
+              "usnat",
+              "ussec",
+              "bleu"
+            ]
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "int",
+              "stg",
+              "prod"
+            ]
+          }
+        },
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
     }
   },
   "properties": {
@@ -175,6 +215,12 @@
           "subscription": {
             "type": "string",
             "minLength": 1
+          },
+          "executionConstraints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/executionConstraint"
+            }
           },
           "subscriptionProvisioning": {
             "type": "object",

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -9,6 +9,20 @@ resourceGroups:
 - name: regional
   resourceGroup: '{{ .regionRG  }}'
   subscription: '{{ .svc.subscription.key }}'
+  executionConstraints:
+    - singleton: true
+      clouds:
+        - ff
+        - usnat
+      environments:
+        - int
+        - stg
+    - clouds:
+        - public
+      environments:
+        - prod
+      regions:
+        - uksouth
   subscriptionProvisioning:
     displayName:
       configRef: svc.subscription.displayName

--- a/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -4,7 +4,22 @@ buildStep:
   - build
   command: make
 resourceGroups:
-- name: regional
+- executionConstraints:
+  - clouds:
+    - ff
+    - usnat
+    environments:
+    - int
+    - stg
+    singleton: true
+  - clouds:
+    - public
+    environments:
+    - prod
+    regions:
+    - uksouth
+    singleton: false
+  name: regional
   resourceGroup: hcp-underlay-uks
   steps:
   - action: Shell


### PR DESCRIPTION
We need to be able to target resource groups to their respective execution contexts - some are global, some are regional, etc. This PR exposes the entire set of constraints that Ev2 provides, factored in a more consumable way.