### PR TITLE
pkg/types: return only unique dependencies

### DIFF
--- a/pkg/types/arm.go
+++ b/pkg/types/arm.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -89,5 +90,7 @@ func (s *ARMStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }

--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -16,6 +16,8 @@ package types
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 )
 
 type Step interface {
@@ -39,6 +41,13 @@ type StepDependency struct {
 	ResourceGroup string `json:"resourceGroup"`
 	// Step is the name of the step being depended on.
 	Step string `json:"step"`
+}
+
+func SortDependencies(a, b StepDependency) int {
+	if cmp := strings.Compare(a.ResourceGroup, b.ResourceGroup); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(a.Step, b.Step)
 }
 
 func (m *StepMeta) StepName() string {
@@ -87,6 +96,8 @@ func (s *DelegateChildZoneStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -110,6 +121,8 @@ func (s *SetCertificateIssuerStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -136,6 +149,8 @@ func (s *CreateCertificateStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -155,6 +170,8 @@ func (s *ResourceProviderRegistrationStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -187,6 +204,8 @@ func (s *LogsStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -208,6 +227,8 @@ func (s *FeatureRegistrationStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -274,6 +295,8 @@ func (s *KustoStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -295,6 +318,8 @@ func (s *Pav2ManageAppIdStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 
@@ -317,5 +342,7 @@ func (s *Pav2AddAccountStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }

--- a/pkg/types/common_test.go
+++ b/pkg/types/common_test.go
@@ -1,0 +1,285 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRequiredInputs(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		input    Step
+		expected []StepDependency
+	}{
+		{
+			name: "shell full",
+			input: &ShellStep{
+				Variables: []Variable{
+					{Value: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}}},
+					{Value: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg2", Step: "step2"}}}},
+				},
+				ShellIdentity: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg2", Step: "step2"},
+			},
+		},
+		{
+			name:  "shell empty",
+			input: &ShellStep{},
+		},
+		{
+			name: "arm full",
+			input: &ARMStep{
+				Variables: []Variable{
+					{Value: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}}},
+					{Value: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg2", Step: "step2"}}}},
+				},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg2", Step: "step2"},
+			},
+		},
+		{
+			name:  "arm empty",
+			input: &ARMStep{},
+		},
+		{
+			name: "delegate full",
+			input: &DelegateChildZoneStep{
+				ParentZone: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				ChildZone:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg2", Step: "step2"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg2", Step: "step2"},
+			},
+		},
+		{
+			name:  "delegate empty",
+			input: &DelegateChildZoneStep{},
+		},
+		{
+			name: "issuer full",
+			input: &SetCertificateIssuerStep{
+				VaultBaseUrl:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				Issuer:         Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				SecretKeyVault: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				SecretName:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				ApplicationId:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+			},
+		},
+		{
+			name:  "issuer empty",
+			input: &SetCertificateIssuerStep{},
+		},
+		{
+			name: "cert full",
+			input: &CreateCertificateStep{
+				VaultBaseUrl:    Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				CertificateName: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				ContentType:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				SAN:             Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				Issuer:          Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				SecretKeyVault:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step5"}}},
+				SecretName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step6"}}},
+				ApplicationId:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step7"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+				{ResourceGroup: "rg", Step: "step5"},
+				{ResourceGroup: "rg", Step: "step6"},
+				{ResourceGroup: "rg", Step: "step7"},
+			},
+		},
+		{
+			name:  "cert empty",
+			input: &CreateCertificateStep{},
+		},
+		{
+			name: "rp full",
+			input: &ResourceProviderRegistrationStep{
+				ResourceProviderNamespaces: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name:  "rp empty",
+			input: &ResourceProviderRegistrationStep{},
+		},
+		{
+			name: "image mirror full",
+			input: &ImageMirrorStep{
+				TargetACR:          Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SourceRegistry:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				Repository:         Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				Digest:             Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				PullSecretKeyVault: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step1"}}},
+				PullSecretName:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step1"}}},
+				ShellIdentity:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step1"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+			},
+		},
+		{
+			name:  "image mirror empty",
+			input: &ImageMirrorStep{},
+		},
+		{
+			name: "logs full",
+			input: &LogsStep{
+				TypeName:        Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretKeyVault:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				SecretName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				Environment:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				AccountName:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				MetricsAccount:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				AdminAlias:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step5"}}},
+				AdminGroup:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step6"}}},
+				SubscriptionId:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step7"}}},
+				Namespace:       Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step8"}}},
+				CertSAN:         Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step8"}}},
+				CertDescription: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step9"}}},
+				ConfigVersion:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step9"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+				{ResourceGroup: "rg", Step: "step5"},
+				{ResourceGroup: "rg", Step: "step6"},
+				{ResourceGroup: "rg", Step: "step7"},
+				{ResourceGroup: "rg", Step: "step8"},
+				{ResourceGroup: "rg", Step: "step9"},
+			},
+		},
+		{
+			name:  "logs empty",
+			input: &LogsStep{},
+		},
+		{
+			name: "feature full",
+			input: &FeatureRegistrationStep{
+				SecretKeyVault: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretName:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				FeatureFlags:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+			},
+		},
+		{
+			name:  "feature empty",
+			input: &FeatureRegistrationStep{},
+		},
+		{
+			name: "provider full",
+			input: &ProviderFeatureRegistrationStep{
+				IdentityFrom: Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name: "ev2 full",
+			input: &Ev2RegistrationStep{
+				IdentityFrom: Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name: "secret full",
+			input: &SecretSyncStep{
+				IdentityFrom: Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name: "kusto full",
+			input: &KustoStep{
+				SecretKeyVault:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretName:       Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				ApplicationId:    Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				ConnectionString: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				Command:          Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step6"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+				{ResourceGroup: "rg", Step: "step6"},
+			},
+		},
+		{
+			name:  "kusto empty",
+			input: &KustoStep{},
+		},
+		{
+			name: "manageapp full",
+			input: &Pav2ManageAppIdStep{
+				SecretKeyVault:    Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretName:        Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SMEAppidParameter: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name:  "manageapp empty",
+			input: &Pav2ManageAppIdStep{},
+		},
+		{
+			name: "addaccount full",
+			input: &Pav2AddAccountStep{
+				SecretKeyVault:             Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretName:                 Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				StorageAccount:             Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				SMEEndpointSuffixParameter: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+			},
+		},
+		{
+			name:  "addaccount empty",
+			input: &Pav2AddAccountStep{},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if diff := cmp.Diff(testCase.expected, testCase.input.RequiredInputs()); diff != "" {
+				t.Errorf("required inputs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/types/imagemirror.go
+++ b/pkg/types/imagemirror.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"slices"
 
 	_ "embed"
 )
@@ -48,6 +49,8 @@ func (s *ImageMirrorStep) RequiredInputs() []StepDependency {
 			deps = append(deps, val.Input.StepDependency)
 		}
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -14,7 +14,10 @@
 
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // ShellStep represents a shell step
 // This struct supports fluent interface With... methods.
@@ -73,6 +76,8 @@ func (s *ShellStep) RequiredInputs() []StepDependency {
 	if s.ShellIdentity.Input != nil {
 		deps = append(deps, s.ShellIdentity.Input.StepDependency)
 	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
 	return deps
 }
 


### PR DESCRIPTION
While the previous implementation was perfectly functional, it was not super ergonomic. We can do better by returning a set of unique dependencies in deterministic order.