### PR TITLE
on-demand.sh: Specify output format for "az acr login"

### DIFF
--- a/pkg/types/on-demand.sh
+++ b/pkg/types/on-demand.sh
@@ -40,7 +40,7 @@ az keyvault secret download --vault-name "${PULL_SECRET_KV}" --name "${PULL_SECR
 
 # ACR login to target registry
 echo "Logging into target ACR ${TARGET_ACR}."
-if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors 2>&1 )"; then
+if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors --output json 2>&1 )"; then
   RESPONSE="${output}"
 else
   echo "Failed to log in to ACR ${TARGET_ACR}: ${output}"


### PR DESCRIPTION
Don't rely on the user's default output format to be "json"; be explicit.

(My default output format is "table".)