### PR TITLE
pkg/config: add a method to retrieve value provenance

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -258,18 +258,18 @@ func (cr *configResolver) GetRegionConfiguration(region string) (types.Configura
 	if !hasCloud {
 		return nil, fmt.Errorf("the cloud %s is not found in the config", cr.cloud)
 	}
-	types.MergeConfiguration(cfg, cloudCfg.Defaults)
+	cfg = types.MergeConfiguration(cfg, cloudCfg.Defaults)
 	envCfg, hasEnv := cloudCfg.Overrides[cr.environment]
 	if !hasEnv {
 		return nil, fmt.Errorf("the deployment env %s is not found under cloud %s", cr.environment, cr.cloud)
 	}
-	types.MergeConfiguration(cfg, envCfg.Defaults)
+	cfg = types.MergeConfiguration(cfg, envCfg.Defaults)
 	regionCfg, hasRegion := envCfg.Overrides[region]
 	if !hasRegion {
 		// a missing region just means we use default values
 		regionCfg = types.Configuration{}
 	}
-	types.MergeConfiguration(cfg, regionCfg)
+	cfg = types.MergeConfiguration(cfg, regionCfg)
 	return cfg, nil
 }
 
@@ -280,12 +280,12 @@ func (cr *configResolver) GetConfiguration() (types.Configuration, error) {
 	if !hasCloud {
 		return nil, fmt.Errorf("the cloud %s is not found in the config", cr.cloud)
 	}
-	types.MergeConfiguration(cfg, cloudCfg.Defaults)
+	cfg = types.MergeConfiguration(cfg, cloudCfg.Defaults)
 	envCfg, hasEnv := cloudCfg.Overrides[cr.environment]
 	if !hasEnv {
 		return nil, fmt.Errorf("the deployment env %s is not found under cloud %s", cr.environment, cr.cloud)
 	}
-	types.MergeConfiguration(cfg, envCfg.Defaults)
+	cfg = types.MergeConfiguration(cfg, envCfg.Defaults)
 
 	return cfg, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -120,8 +120,8 @@ func TestMergeConfiguration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			types.MergeConfiguration(tc.base, tc.override)
-			require.Empty(t, cmp.Diff(tc.expected, tc.base))
+			output := types.Configuration(types.MergeConfiguration(tc.base, tc.override))
+			require.Empty(t, cmp.Diff(tc.expected, output))
 		})
 	}
 

--- a/pkg/config/ev2config/config.go
+++ b/pkg/config/ev2config/config.go
@@ -39,12 +39,12 @@ func ResolveConfig(cloud, region string) (types.Configuration, error) {
 	if !hasCloud {
 		return nil, fmt.Errorf("failed to find cloud %s", cloud)
 	}
-	types.MergeConfiguration(cfg, cloudCfg.Defaults)
+	cfg = types.MergeConfiguration(cfg, cloudCfg.Defaults)
 	regionCfg, hasRegion := cloudCfg.Regions[region]
 	if !hasRegion {
 		return nil, fmt.Errorf("failed to find region %s in cloud %s", region, cloud)
 	}
-	types.MergeConfiguration(cfg, regionCfg)
+	cfg = types.MergeConfiguration(cfg, regionCfg)
 	return cfg, nil
 }
 

--- a/pkg/config/testdata/zz_fixture_TestConfigProvider.yaml
+++ b/pkg/config/testdata/zz_fixture_TestConfigProvider.yaml
@@ -44,6 +44,7 @@ maestro_image: aro-hcp-int.azurecr.io/maestro-server:the-stable-one
 managementClusterRG: hcp-underlay-uks-mgmt-1
 managementClusterSubscription: hcp-uksouth
 parentZone: example.com
+partialValue: public-int-uksouth-value
 provider: Self
 region: uksouth
 regionRG: hcp-underlay-uks
@@ -66,5 +67,6 @@ svc:
     displayName: 'Red Hat OpenShift HCP Service - int: uksouth'
     key: hcp-int-svc-uksouth
 test: uksouth
+ubiquitousValue: public-int-uksouth-value
 vaultBaseUrl: myvault.azure.com
 vaultDomainSuffix: vault.azure.net

--- a/pkg/config/types/configuration.go
+++ b/pkg/config/types/configuration.go
@@ -37,9 +37,9 @@ func (v Configuration) GetByPath(path string) (any, error) {
 	return current, nil
 }
 
-// Merges Configuration, returns merged Configuration
-// However the return value is only used for recursive updates on the map
-// The actual merged Configuration are updated in the base map
+// MergeConfiguration returns a new configuration holding keys from base, unless they have been overridden.
+// This function does not mutate its inputs, but returns a `map[string]any` instead of `types.Configuration`, so
+// if your consumer is sensitive to the distinction, remember to cast the output.
 func MergeConfiguration(base, override Configuration) map[string]any {
 	if base == nil {
 		base = Configuration{}
@@ -47,16 +47,20 @@ func MergeConfiguration(base, override Configuration) map[string]any {
 	if override == nil {
 		override = Configuration{}
 	}
+	output := make(Configuration, len(base))
+	for k, v := range base {
+		output[k] = v
+	}
 	for k, newValue := range override {
-		if baseValue, exists := base[k]; exists {
+		if baseValue, exists := output[k]; exists {
 			srcMap, srcMapOk := newValue.(map[string]any)
 			dstMap, dstMapOk := baseValue.(map[string]any)
 			if srcMapOk && dstMapOk {
 				newValue = MergeConfiguration(dstMap, srcMap)
 			}
 		}
-		base[k] = newValue
+		output[k] = newValue
 	}
 
-	return base
+	return output
 }

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -67,11 +67,14 @@ defaults:
   storage:
     accountName: arotestaccount
     storageSuffix: aro-int
+  ubiquitousValue: global-value
+  partialValue: global-value
 clouds:
   ff:
     defaults: {}
   public:
-    defaults: {}
+    defaults:
+      ubiquitousValue: public-value
     environments:
       dev:
         defaults:
@@ -82,6 +85,9 @@ clouds:
         defaults:
           maestro_helm_chart: oci://aro-hcp-int.azurecr.io/helm/server
           maestro_image: aro-hcp-int.azurecr.io/maestro-server:the-stable-one
+          ubiquitousValue: public-int-value
         regions:
           uksouth:
             test: uksouth
+            ubiquitousValue: public-int-uksouth-value
+            partialValue: public-int-uksouth-value


### PR DESCRIPTION
pkg/config: stop mutating the input during merge

Mutating your inputs is bad practice, and makes it impossible to know
what will happen later when the same object is used for more merges.
There's no need to do it, so we can just return a copy.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

pkg/config: add a method to retrieve value provenance

We would like to know, for a given value, how it came to be - what
levels of the stack provide defaults, which overwrite which, etc. This
was previously not possible as getting at the higher-level defaults is
not supported; instead of opening that API, this commit simply adds a
new method to check the provenance of a value.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

