### PR TITLE
Pav2 step: Add an operation field to run specific Pav2 geneva action.

### DIFF
--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -330,15 +330,16 @@ const StepActionPav2 = "Pav2"
 
 type Pav2Step struct {
 	StepMeta                   `json:",inline"`
-	SecretKeyVault             Value `json:"secretKeyVault,omitempty"`
-	SecretName                 Value `json:"secretName,omitempty"`
-	StorageAccount             Value `json:"storageAccount,omitempty"`
-	SMEEndpointSuffixParameter Value `json:"smeEndpointSuffixParameter,omitempty"`
-	SMEAppidParameter          Value `json:"smeAppidParameter,omitempty"`
+	SecretKeyVault             Value  `json:"secretKeyVault,omitempty"`
+	SecretName                 Value  `json:"secretName,omitempty"`
+	StorageAccount             Value  `json:"storageAccount,omitempty"`
+	SMEEndpointSuffixParameter Value  `json:"smeEndpointSuffixParameter,omitempty"`
+	SMEAppidParameter          Value  `json:"smeAppidParameter,omitempty"`
+	Operation                  string `json:"operation,omitempty"`
 }
 
 func (s *Pav2Step) Description() string {
-	return fmt.Sprintf("Step %s\n Kind: %s\n", s.Name, s.Action)
+	return fmt.Sprintf("Step %s\n Kind: %s\n Operation: %s\n", s.Name, s.Action, s.Operation)
 }
 
 func (s *Pav2Step) RequiredInputs() []StepDependency {

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -521,6 +521,24 @@
         "action": {
           "const": "Pav2"
         },
+        "operation": {
+          "type": "string",
+          "description": "Specifies the type of Pav2 operation to run via Geneva Actions.",
+          "oneOf": [
+            {
+              "const": "All",
+              "description": "Run all Pav2 operations"
+            },
+            {
+              "const": "AddAccount",
+              "description": "Add Pav2 Account"
+            },
+            {
+              "const": "ManageAppId",
+              "description": "Manage the application ID"
+            }
+          ]
+        },
         "secretKeyVault": {
           "$ref": "#/definitions/value"
         },
@@ -540,12 +558,61 @@
           "$ref": "#/definitions/stepDependencies"
         }
       },
-      "required": [
-        "secretKeyVault",
-        "secretName",
-        "storageAccount",
-        "smeEndpointSuffixParameter",
-        "smeAppidParameter"
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "All"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "operation",
+              "secretKeyVault",
+              "secretName",
+              "storageAccount",
+              "smeEndpointSuffixParameter",
+              "smeAppidParameter"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "AddAccount"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "operation",
+              "secretKeyVault",
+              "secretName",
+              "storageAccount",
+              "smeEndpointSuffixParameter"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "ManageAppId"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "operation",
+              "secretKeyVault",
+              "secretName",
+              "smeAppidParameter"
+            ]
+          }
+        }
       ]
     },
     "logsStep": {

--- a/pkg/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pkg/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -341,7 +341,8 @@ resourceGroups:
     targetACR:
       value: targetACR
   - action: Pav2
-    name: pav2
+    name: pav2-All
+    operation: All
     secretKeyVault:
       configRef: ev2.assistedId.certificate.keyVault
     secretName:
@@ -355,6 +356,32 @@ resourceGroups:
       configRef: storage.storageSuffix
     storageAccount:
       configRef: storage.accountName
+  - action: Pav2
+    name: pav2-AddAccount
+    operation: AddAccount
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    smeAppidParameter: {}
+    smeEndpointSuffixParameter:
+      configRef: storage.storageSuffix
+    storageAccount:
+      configRef: storage.accountName
+  - action: Pav2
+    name: pav2-ManageAppId
+    operation: ManageAppId
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    smeAppidParameter:
+      input:
+        name: kvUrl
+        resourceGroup: regional
+        step: deploy
+    smeEndpointSuffixParameter: {}
+    storageAccount: {}
   subscription: hcp-uksouth
   subscriptionProvisioning:
     displayName:


### PR DESCRIPTION
Pav2 step: Add an operation field to run specific Pav2 geneva action. We need this change as the HCP billing infra do not have storage accounts and hence this helps in decoupling the steps.