### PR TITLE
pkg/types: allow Shell steps to opt into smaller archives

### DIFF
--- a/pkg/types/common_test.go
+++ b/pkg/types/common_test.go
@@ -278,6 +278,7 @@ func TestIsWellFormedOverInputs(t *testing.T) {
 		expected bool
 	}{
 		{in: &ShellStep{}, expected: false},
+		{in: &ShellStep{ArchiveSubdir: "something"}, expected: true},
 		{in: &HelmStep{}, expected: true},
 		{in: &ARMStep{}, expected: true},
 		{in: &ARMStackStep{}, expected: true},

--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -362,6 +362,9 @@
         "subnetName": {
           "type": "string"
         },
+        "archiveSubDir": {
+          "type": "string"
+        },
         "shellIdentity": {
           "$ref": "#/definitions/value"
         },

--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -23,14 +23,20 @@ const StepActionShell = "Shell"
 
 // ShellStep represents a shell step
 type ShellStep struct {
-	StepMeta      `json:",inline"`
-	AKSCluster    string      `json:"aksCluster,omitempty"`
-	Command       string      `json:"command,omitempty"`
-	Variables     []Variable  `json:"variables,omitempty"`
-	DryRun        DryRun      `json:"dryRun,omitempty"`
-	References    []Reference `json:"references,omitempty"`
-	SubnetName    string      `json:"subnetName,omitempty"`
-	ShellIdentity Value       `json:"shellIdentity,omitempty"`
+	StepMeta   `json:",inline"`
+	AKSCluster string      `json:"aksCluster,omitempty"`
+	Command    string      `json:"command,omitempty"`
+	Variables  []Variable  `json:"variables,omitempty"`
+	DryRun     DryRun      `json:"dryRun,omitempty"`
+	References []Reference `json:"references,omitempty"`
+	SubnetName string      `json:"subnetName,omitempty"`
+	// ArchiveSubdir is the relative path from the pipeline definition to the directory which will be the *only* content
+	// available to the shell during execution. If and only if this is set will a shell step be eligible for being skipped
+	// during incremental execution; it is in the best interest of the author to contain the smallest amount of content
+	// in the directory, as any change to any input will cause a re-run.
+	ArchiveSubdir string `json:"archiveSubdir,omitempty"`
+	// ShellIdentity is the ID of the managed identity with which the shell step will execute in an Ev2 context. Required.
+	ShellIdentity Value `json:"shellIdentity"`
 }
 
 // Reference represents a configurable reference
@@ -66,7 +72,7 @@ func (s *ShellStep) RequiredInputs() []StepDependency {
 
 func (s *ShellStep) IsWellFormedOverInputs() bool {
 	// raw shell steps capture the whole repository as an archive input, so they are not well-formed
-	return false
+	return s.ArchiveSubdir != ""
 }
 
 // ShellValidationStep represents a shell step that is a validation step.

--- a/pkg/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pkg/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -34,6 +34,7 @@ resourceGroups:
     - configRef: maestro_image
       name: MAESTRO_IMAGE
   - action: Shell
+    archiveSubdir: something
     command: make deploy
     dryRun:
       variables:

--- a/testdata/pipeline.yaml
+++ b/testdata/pipeline.yaml
@@ -45,6 +45,7 @@ resourceGroups:
   - name: dry-run
     action: Shell
     command: make deploy
+    archiveSubDir: something
     shellIdentity:
       configRef: aroDevopsMsiId
     dryRun:


### PR DESCRIPTION
Only when a shell step opts into a smaller archive and we can track what is in there will we be able to detect when shell steps can be skipped during incremental rollout.