### PR TITLE
Resolve ownership conflicts for existing helm releases that used clie…nt-side-apply

### DIFF
--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -343,6 +343,7 @@ func runHelmUpgrade(ctx context.Context, logger logr.Logger, opts *Options) (*he
 	upgradeClient.Timeout = opts.Timeout
 	upgradeClient.Install = true
 	upgradeClient.ServerSideApply = "true"
+	upgradeClient.ForceConflicts = true
 
 	if opts.DryRun {
 		upgradeClient.DryRun = true


### PR DESCRIPTION
this commit resolves the ownership conflict by enabling the --force-conflicts flag during the Helm upgrade operation.