### PR TITLE
Revert "Resolve ownership conflicts for existing helm releases that used client-side-apply"

### DIFF
--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -343,7 +343,6 @@ func runHelmUpgrade(ctx context.Context, logger logr.Logger, opts *Options) (*he
 	upgradeClient.Timeout = opts.Timeout
 	upgradeClient.Install = true
 	upgradeClient.ServerSideApply = "true"
-	upgradeClient.ForceConflicts = true
 
 	if opts.DryRun {
 		upgradeClient.DryRun = true


### PR DESCRIPTION
This reverts commit 845f8b2bd969fec884b0f90d8f4005ff8cfad9b1.

This didn't solve the issue.