### PR TITLE
pkg/helm: force conflicts

### DIFF
--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -323,6 +323,7 @@ func runHelmUpgrade(ctx context.Context, logger logr.Logger, opts *Options) (*he
 		installClient.Namespace = opts.ReleaseNamespace
 		installClient.Timeout = opts.Timeout
 		installClient.ServerSideApply = true
+		installClient.ForceConflicts = true
 
 		if opts.DryRun {
 			installClient.DryRun = true
@@ -346,6 +347,7 @@ func runHelmUpgrade(ctx context.Context, logger logr.Logger, opts *Options) (*he
 	upgradeClient.Timeout = opts.Timeout
 	upgradeClient.Install = true
 	upgradeClient.ServerSideApply = "true"
+	upgradeClient.ForceConflicts = true
 
 	if opts.DryRun {
 		upgradeClient.DryRun = true


### PR DESCRIPTION
We did not create our Helm releases originally using Helm v4 or server-side apply, so there are loads of places where we need to become the sole manager of the field, even though we technically already were, but since we were using update instead of apply it will not be correctly captured.