### PR TITLE
pkg/helm: install CRDs

### DIFF
--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -324,6 +324,7 @@ func runHelmUpgrade(ctx context.Context, logger logr.Logger, opts *Options) (*he
 		installClient.Timeout = opts.Timeout
 		installClient.ServerSideApply = true
 		installClient.ForceConflicts = true
+		installClient.IncludeCRDs = true
 
 		if opts.DryRun {
 			installClient.DryRun = true


### PR DESCRIPTION
The upgrade client asks you to opt *out* of installing or upgrading CRDs. The install client asks you to opt *in*. Great.