### PR TITLE
Permit Microsoft.Azure.ARO.ARMManifest.* servicegroup definitions

### DIFF
--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -97,7 +97,7 @@ type InvalidServiceGroupError struct {
 }
 
 func (e *InvalidServiceGroupError) Error() string {
-	return fmt.Sprintf("invalid service group %s, must be of form Microsoft.Azure.ARO.{Classic|HCP|ARMManifest}.Component(.Subcomponent)?", e.ServiceGroup)
+	return fmt.Sprintf("invalid service group %s, must be of form Microsoft.Azure.ARO.Service.Component(.Subcomponent)?", e.ServiceGroup)
 }
 
 func (v *validator) walk(s Service) error {
@@ -110,7 +110,7 @@ func (v *validator) walk(s Service) error {
 		return &InvalidServiceGroupError{ServiceGroup: s.ServiceGroup}
 	}
 
-	if parts[3] != "Classic" && parts[3] != "HCP" && parts[3] != "ARMManifest" {
+	if parts[3] == "" {
 		return &InvalidServiceGroupError{ServiceGroup: s.ServiceGroup}
 	}
 

--- a/pkg/topology/types_test.go
+++ b/pkg/topology/types_test.go
@@ -188,13 +188,13 @@ services:
 			err: false,
 		},
 		{
-			name: "invalid service group component",
+			name: "unknown service group component",
 			input: `services:
 - serviceGroup: Microsoft.Azure.ARO.Oops.Doops.Troops
   purpose: stuff
   metadata:
     pipeline: foo`,
-			err: true,
+			err: false,
 		},
 		{
 			name: "missing service group component",


### PR DESCRIPTION
Quick update to servicegroup validation to permit `Microsoft.Azure.ARO.ARMManifest.*` servicegroups, alongside the already-supported `Microsoft.Azure.ARO.Classic.*` and `Microsoft.Azure.ARO.HCP.*` definitions. Tests were also updated to ensure all three definitions are considered valid. 