### PR TITLE
Delete Southeast Asia 3 region from config

### DIFF
--- a/pkg/config/ev2config/config.yaml
+++ b/pkg/config/ev2config/config.yaml
@@ -451,12 +451,6 @@ clouds:
         geography: Asia Pacific
         regionFriendlyName: Southeast Asia
         regionShortName: sg
-      southeastasia3:
-        availabilityZoneCount: 0
-        geoShortId: my
-        geography: Malaysia
-        regionFriendlyName: Southeast Asia 3
-        regionShortName: SG3
       southeastus:
         availabilityZoneCount: 1
         geoShortId: us


### PR DESCRIPTION
Removed Southeast Asia 3 region configuration.

Redo:
https://github.com/Azure/ARO-Tools/commit/cbde53bf5dc3e8425c356183bd5d37d3744c8f81

https://issues.redhat.com/browse/AROSLSRE-247