### PR TITLE
Add a set of sane duration values

### DIFF
--- a/pkg/types/pipeline.schema.v1.json
+++ b/pkg/types/pipeline.schema.v1.json
@@ -34,7 +34,15 @@
               "maximum": 10
             },
             "durationBetweenRetries": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "1m",
+                "2m",
+                "5m",
+                "10m",
+                "15m",
+                "30m"
+              ]
             }
           }
         }


### PR DESCRIPTION
Ev2 does not allow any value: 
https://ev2docs.azure.net/features/rollout-management/retry-skip.html

https://issues.redhat.com/browse/AROSLSRE-443