### PR TITLE
fix: Add retry logic to ACR login in on-demand sync script

### DIFF
--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -9,12 +9,12 @@ retry() {
     until "$@"; do
         count=$((count + 1))
         if [[ "${count}" -ge "${retries}" ]]; then
-            echo "Command failed after ${retries} attempts: $*"
+            echo "Command failed after ${retries} attempts: $*" >&2
             return 1
         fi
-        local wait=$((2 ** count))
-        echo "Command failed (attempt ${count}/${retries}). Retrying in ${wait}s..."
-        sleep "${wait}"
+        local delay=$((2 ** count))
+        echo "Command failed (attempt ${count}/${retries}). Retrying in ${delay}s..." >&2
+        sleep "${delay}"
     done
 }
 
@@ -156,7 +156,7 @@ copyImageFromOciLayout() {
     USERNAME="00000000-0000-0000-0000-000000000000"
     acr_login_oci() {
       if ! PASSWORD=$(az acr login --name "$TARGET_ACR" --expose-token --only-show-errors --output tsv --query accessToken); then
-        echo "Failed to get ACR access token for ${TARGET_ACR}"
+        echo "Failed to get ACR access token for ${TARGET_ACR}" >&2
         return 1
       fi
     }

--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -2,6 +2,22 @@
 
 set -euo pipefail
 
+retry() {
+    local retries="${1}"
+    shift
+    local count=0
+    until "$@"; do
+        count=$((count + 1))
+        if [[ "${count}" -ge "${retries}" ]]; then
+            echo "Command failed after ${retries} attempts: $*"
+            return 1
+        fi
+        local wait=$((2 ** count))
+        echo "Command failed (attempt ${count}/${retries}). Retrying in ${wait}s..."
+        sleep "${wait}"
+    done
+}
+
 copyImageFromRegistry() {
     # shortcut mirroring if the source registry is the same as the target ACR
     REQUIRED_REGISTRY_VARS=("TARGET_ACR" "SOURCE_REGISTRY")
@@ -57,12 +73,15 @@ copyImageFromRegistry() {
 
     # ACR login to target registry
     echo "Logging into target ACR ${TARGET_ACR}."
-    if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors --output json 2>&1 )"; then
-      RESPONSE="${output}"
-    else
-      echo "Failed to log in to ACR ${TARGET_ACR}: ${output}"
-      exit 1
-    fi
+    acr_login_target() {
+      if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors --output json 2>&1 )"; then
+        RESPONSE="${output}"
+      else
+        echo "Failed to log in to ACR ${TARGET_ACR}: ${output}"
+        return 1
+      fi
+    }
+    retry 5 acr_login_target
     TARGET_ACR_LOGIN_SERVER="$(jq --raw-output .loginServer <<<"${RESPONSE}" )"
     oras login --registry-config "${AUTH_JSON}" \
                --username 00000000-0000-0000-0000-000000000000 \
@@ -135,8 +154,11 @@ copyImageFromOciLayout() {
 
     echo "Getting the ACR access token."
     USERNAME="00000000-0000-0000-0000-000000000000"
-    PASSWORD=$(az acr login --name "$TARGET_ACR" --expose-token --output tsv --query accessToken)
- 
+    acr_login_oci() {
+      PASSWORD=$(az acr login --name "$TARGET_ACR" --expose-token --output tsv --query accessToken)
+    }
+    retry 5 acr_login_oci
+
     echo "Logging in with ORAS."
     oras login $TARGET_ACR_LOGIN_SERVER --username $USERNAME  --password-stdin <<< $PASSWORD
    

--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -155,7 +155,10 @@ copyImageFromOciLayout() {
     echo "Getting the ACR access token."
     USERNAME="00000000-0000-0000-0000-000000000000"
     acr_login_oci() {
-      PASSWORD=$(az acr login --name "$TARGET_ACR" --expose-token --output tsv --query accessToken)
+      if ! PASSWORD=$(az acr login --name "$TARGET_ACR" --expose-token --only-show-errors --output tsv --query accessToken); then
+        echo "Failed to get ACR access token for ${TARGET_ACR}"
+        return 1
+      fi
     }
     retry 5 acr_login_oci
 

--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -77,7 +77,7 @@ copyImageFromRegistry() {
       if output="$( az acr login --name "${TARGET_ACR}" --expose-token --only-show-errors --output json 2>&1 )"; then
         RESPONSE="${output}"
       else
-        echo "Failed to log in to ACR ${TARGET_ACR}: ${output}"
+        echo "Failed to log in to ACR ${TARGET_ACR}: ${output}" >&2
         return 1
       fi
     }


### PR DESCRIPTION
## Summary
- Adds a `retry` helper with exponential backoff (up to 4 retries with 2/4/8/16s waits)
- Wraps both `az acr login` calls in `on-demand.sh` (`copyImageFromRegistry` and `copyImageFromOciLayout`) with retry
- Fixes transient Ev2 image mirroring failures caused by managed identity token errors (`JSON is invalid: Expecting value`)

## Context
During Ev2 deployments, `sync.sh` (generated from `on-demand.sh`) runs as a separate process from the Ev2 wrapper script. The wrapper defines its own `az_retry` function with retry logic, but `sync.sh` does its own `az acr login` without any retry. Transient Azure managed identity token issues cause the login to fail with `JSON is invalid`, which is recoverable on retry but currently causes the entire deployment step to fail.

## Test plan
- [x] Verify script syntax: `bash -n pipelines/types/on-demand.sh`
- [ ] Downstream: bump ARO-Tools in sdp-pipelines, regenerate test fixtures