### PR TITLE
Add skip flag to grafana datasources sync

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -725,6 +725,9 @@ type GrafanaDatasourcesStep struct {
 
 	GrafanaName string `json:"grafanaName"`
 
+	// SkipSync indicates whether to skip syncing datasources. It is intended for prow jobs to skip syncing datasources.
+	SkipSync bool `json:"skipSync,omitempty"`
+
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.
 	IdentityFrom Input `json:"identityFrom,omitempty"`
 }

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -690,6 +690,9 @@
             "grafanaName": {
               "type": "string"
             },
+            "skipSync": {
+              "type": "string"
+            },
             "identityFrom": {
               "$ref": "#/definitions/input"
             }

--- a/tools/grafanactl/cmd/sync/cmd.go
+++ b/tools/grafanactl/cmd/sync/cmd.go
@@ -61,6 +61,11 @@ func NewSyncCommand(group string) (*cobra.Command, error) {
 }
 
 func (opts *RawSyncDashboardsOptions) Run(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	if opts.SkipSync {
+		logger.Info("Skipping dashboard sync")
+		return nil
+	}
 	validated, err := opts.Validate(ctx)
 	if err != nil {
 		return fmt.Errorf("validation failed: %w", err)

--- a/tools/grafanactl/cmd/sync/options.go
+++ b/tools/grafanactl/cmd/sync/options.go
@@ -33,6 +33,7 @@ import (
 type RawSyncDashboardsOptions struct {
 	*base.BaseOptions
 	ConfigFilePath string
+	SkipSync       bool
 }
 
 // validatedSyncDashboardsOptions is a private struct that enforces the options validation pattern.
@@ -69,6 +70,7 @@ func BindSyncDashboardsOptions(opts *RawSyncDashboardsOptions, cmd *cobra.Comman
 
 	flags := cmd.Flags()
 	flags.StringVar(&opts.ConfigFilePath, "config-file", "", "Path to config file with Grafana dashboard references (absolute or relative path, required)")
+	flags.BoolVar(&opts.SkipSync, "skip-sync", false, "Skip syncing dashboards")
 
 	_ = cmd.MarkFlagRequired("config-file")
 	return nil


### PR DESCRIPTION
In prow environments we want to skip the sync entirely and not wait for it. We could have used the dry-run, but IMHO it would be better to get rid of dry run instead, since we are not actively using it anywhere. Also Dry-run capabilities have been removed from templatize, since we did not use them and they caused confusion.