### PR TITLE
pipelines: fix ProwJobStep DryRun type from bool to DryRun struct

### DIFF
--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -519,7 +519,10 @@ resourceGroups:
   - name: e2e2
     action: ProwJob
     tokenKeyvault: "{{ .global.keyVault.name }}.vault.azure.net"
-    dryRun: true
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
     tokenSecret: "{{ .e2e.prow.globalKeyVaultTokenSecret }}"
     jobName: "{{ .e2e.regionTest.prowJobName }}"
     gatePromotion: "{{ .e2e.regionTest.gatePromotion }}"

--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -659,6 +659,11 @@ func (s *ProwJobStep) Description() string {
 func (s *ProwJobStep) RequiredInputs() []StepDependency {
 
 	var deps []StepDependency
+	for _, val := range s.DryRun.Variables {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
 	for _, val := range []Input{s.IdentityFrom} {
 		deps = append(deps, val.StepDependency)
 	}

--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -646,7 +646,7 @@ type ProwJobStep struct {
 	TokenSecret   string `json:"tokenSecret"`
 	JobName       string `json:"jobName"`
 	GatePromotion string `json:"gatePromotion"` // string-encoded boolean, passed to command as a flag
-	DryRun        bool   `json:"dryRun,omitempty"`
+	DryRun        DryRun `json:"dryRun,omitempty"`
 
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.
 	IdentityFrom Input `json:"identityFrom,omitempty"`

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -634,7 +634,19 @@
               "$ref": "#/definitions/input"
             },
             "dryRun": {
-              "type": "boolean"
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "variables": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/variable"
+                  }
+                }
+              }
             }
           },
           "required": [

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -524,6 +524,7 @@ resourceGroups:
     roleAssignment: test.bicepparam
   validationSteps:
   - action: ProwJob
+    dryRun: {}
     gatePromotion: "true"
     identityFrom:
       name: whatever
@@ -536,7 +537,10 @@ resourceGroups:
     validation:
     - Internal
   - action: ProwJob
-    dryRun: true
+    dryRun:
+      variables:
+      - name: DRY_RUN
+        value: "true"
     gatePromotion: "true"
     identityFrom:
       name: whatever


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-719

### What

Change `ProwJobStep.DryRun` field type from `bool` to `DryRun` struct, matching `ShellStep`. Include `DryRun.Variables` in `ProwJobStep.RequiredInputs` so step dependencies are reflected in the execution graph.

### Why

Commit `ef00889` added `DryRun` to `ProwJobStep` as `bool`, but `classic/rp/e2e/pipeline.yaml` in sdp-pipelines uses it as an object:

```yaml
dryRun:
  variables:
  - name: DRY_RUN
    value: "true"
```

This causes sdp-pipelines CI to fail when the bumper picks up ARO-HCP #5011 (which bumped to this ARO-Tools version):

```
json: cannot unmarshal object into Go struct field ProwJobValidationStep.ProwJobStep.dryRun of type bool
```

The `DryRun` struct type already exists (line 169 in `common.go`) and is used correctly by `ShellStep`. The bool type on `ProwJobStep` was incorrect — the struct is needed to pass `variables` (env vars like `DRY_RUN`) to the prow job executor shell command.

### Changes

- `common.go`: `ProwJobStep.DryRun` type `bool` -> `DryRun`
- `common.go`: `ProwJobStep.RequiredInputs` includes `DryRun.Variables` step dependencies (matching `ShellStep`)
- `pipeline.schema.v1.json`: ProwJob `dryRun` schema from `boolean` to object (matching ShellStep)
- `pipeline.yaml` test fixture: update `dryRun: true` to object form
- Regenerated test fixture

### Testing

`go test ./pipelines/types/...` passes.

### Related

- [ARO-HCP #5026](https://github.com/Azure/ARO-HCP/pull/5026): reverts the broken ARO-Tools bump
- [ARO-HCP #5011](https://github.com/Azure/ARO-HCP/pull/5011): the original bump that exposed this bug