### PR TITLE
Allow loading several topology files into one

### DIFF
--- a/pipelines/topology/testdata/team-a/topology.yaml
+++ b/pipelines/topology/testdata/team-a/topology.yaml
@@ -1,0 +1,8 @@
+services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: pipeline.yaml
+  purpose: HCP service
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Child
+    pipelinePath: child-pipeline.yaml
+    purpose: HCP child service

--- a/pipelines/topology/testdata/team-b/topology.yaml
+++ b/pipelines/topology/testdata/team-b/topology.yaml
@@ -1,0 +1,8 @@
+services:
+- serviceGroup: Microsoft.Azure.ARO.Classic
+  pipelinePath: pipeline.yaml
+  purpose: Classic service
+- serviceGroup: Microsoft.Azure.ARO.HCP.Extension
+  pipelinePath: extension-pipeline.yaml
+  purpose: HCP extension service
+  externalParent: Microsoft.Azure.ARO.HCP

--- a/pipelines/topology/types.go
+++ b/pipelines/topology/types.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -16,6 +17,13 @@ type Topology struct {
 
 	// Entrypoints selects specific sub-trees that are deployed together.
 	Entrypoints []Entrypoint `json:"entrypoints,omitempty"`
+}
+
+type CombinedTopology struct {
+	Topology
+
+	// serviceGroupToTopologyDir maps service group to the directory of the topology file it came from, for use in resolving pipeline paths.
+	serviceGroupToTopologyDir map[string]string
 }
 
 // Service describes an individual service in the tree.
@@ -34,6 +42,10 @@ type Service struct {
 
 	// Metadata is an extension point to store useful information for the service.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Parent service located in a different topology file. Ignored if only one topology file is specified.
+	// Only allowed in input yaml on top-level services (i.e. those listed directly under Services in the topology file, not nested within another service's Children).
+	ExternalParent *string `json:"externalParent,omitempty"`
 }
 
 // Entrypoint describes an individual pipeline in the tree.
@@ -55,11 +67,108 @@ func Load(path string) (*Topology, error) {
 	return &out, yaml.Unmarshal(raw, &out)
 }
 
+func LoadCombined(paths []string) (*CombinedTopology, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("at least one topology file must be provided")
+	}
+
+	combinedTopology := CombinedTopology{
+		serviceGroupToTopologyDir: make(map[string]string),
+	}
+
+	servicesWithExternalParents := make([]*Service, 0)
+	for _, path := range paths {
+		topo, err := Load(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load topology %s: %w", path, err)
+		}
+
+		for i := range topo.Services {
+			err = validateNoExternalParentInChildren(&topo.Services[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to validate topology from %s: %w", path, err)
+			}
+
+			err = accumulateServiceGroupToTopologyDirMapping(&topo.Services[i], filepath.Dir(path), combinedTopology.serviceGroupToTopologyDir)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add topology %s: %w", path, err)
+			}
+
+			// If the length of paths is 1, we can ignore external parents since there is only one topology.
+			// If the length of paths is greater than 1, we defer adding services with external parents
+			// until we've processed all topologies since their external parents may be in later topologies in the list.
+			if topo.Services[i].ExternalParent != nil && len(paths) > 1 {
+				servicesWithExternalParents = append(servicesWithExternalParents, &topo.Services[i])
+			} else {
+				combinedTopology.Services = append(combinedTopology.Services, topo.Services[i])
+			}
+		}
+		combinedTopology.Entrypoints = append(combinedTopology.Entrypoints, topo.Entrypoints...)
+	}
+
+	for i := range servicesWithExternalParents {
+		svc := servicesWithExternalParents[i]
+		externalParent, err := combinedTopology.Lookup(*svc.ExternalParent)
+		if err != nil {
+			// If we can't find the external parent in the combined topology, it's possible it is later
+			// in the list of services with external parents since we haven't guaranteed any ordering on the input topologies.
+			// Look through the remaining services with external parents to see if we can find it before giving up.
+			for j := i + 1; j < len(servicesWithExternalParents); j++ {
+				uncheckedSvc := servicesWithExternalParents[j]
+				externalParent = find(uncheckedSvc, *svc.ExternalParent)
+				if externalParent != nil {
+					break
+				}
+			}
+
+			if externalParent == nil {
+				return nil, fmt.Errorf("service %s references external parent %s that does not exist in the topology: %w", svc.ServiceGroup, *svc.ExternalParent, err)
+			}
+		}
+		externalParent.Children = append(externalParent.Children, *svc)
+	}
+
+	return &combinedTopology, nil
+}
+
 func (t *Topology) Validate() error {
 	return (&validator{
 		seen:       sets.New[string](),
 		duplicates: sets.New[string](),
 	}).validate(t)
+}
+
+func (t *CombinedTopology) GetTopologyDirForServiceGroup(serviceGroup string) (string, error) {
+	dir, exists := t.serviceGroupToTopologyDir[serviceGroup]
+	if !exists {
+		return "", fmt.Errorf("service group %s not found in topology", serviceGroup)
+	}
+	return dir, nil
+}
+
+func accumulateServiceGroupToTopologyDirMapping(s *Service, topologyDir string, mapping map[string]string) error {
+	if existingDir, exists := mapping[s.ServiceGroup]; exists {
+		return fmt.Errorf("duplicate service group %s found in topology in %s and %s; service groups must be unique across topologies", s.ServiceGroup, topologyDir, existingDir)
+	}
+	mapping[s.ServiceGroup] = topologyDir
+	for i := range s.Children {
+		if err := accumulateServiceGroupToTopologyDirMapping(&s.Children[i], topologyDir, mapping); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNoExternalParentInChildren(s *Service) error {
+	for i := range s.Children {
+		if s.Children[i].ExternalParent != nil {
+			return fmt.Errorf("service %s has externalParent set but is a child of %s; externalParent is only allowed on top-level services", s.Children[i].ServiceGroup, s.ServiceGroup)
+		}
+		if err := validateNoExternalParentInChildren(&s.Children[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type validator struct {

--- a/pipelines/topology/types.go
+++ b/pipelines/topology/types.go
@@ -34,6 +34,10 @@ type Service struct {
 
 	// Metadata is an extension point to store useful information for the service.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Parent service located in a different topology file. Ignored if no parent topology file is specified.
+	// Only allowed on top-level services (i.e. those listed directly under Services in the topology file, not nested within another service's Children).
+	ExternalParent *string `json:"externalParent,omitempty"`
 }
 
 // Entrypoint describes an individual pipeline in the tree.
@@ -60,6 +64,39 @@ func (t *Topology) Validate() error {
 		seen:       sets.New[string](),
 		duplicates: sets.New[string](),
 	}).validate(t)
+}
+
+func (t *Topology) AddChildTopology(path string) error {
+	childTopo, err := Load(path)
+	if err != nil {
+		return fmt.Errorf("failed to load child topology from %s: %w", path, err)
+	}
+	for _, svc := range childTopo.Services {
+		err = validateNoExternalParentInChildren(svc)
+		if err != nil {
+			return fmt.Errorf("failed to add child topology from %s: %w", path, err)
+		}
+		if svc.ExternalParent != nil {
+			externalParent, err := t.Lookup(*svc.ExternalParent)
+			if err != nil {
+				return fmt.Errorf("service %s in child topology %s references external parent %s that does not exist in the main topology: %w", svc.ServiceGroup, path, *svc.ExternalParent, err)
+			}
+			externalParent.Children = append(externalParent.Children, svc)
+		}
+	}
+	return nil
+}
+
+func validateNoExternalParentInChildren(svc Service) error {
+	for _, child := range svc.Children {
+		if child.ExternalParent != nil {
+			return fmt.Errorf("service %s has externalParent set but is a child of %s; externalParent is only allowed on top-level services", child.ServiceGroup, svc.ServiceGroup)
+		}
+		if err := validateNoExternalParentInChildren(child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type validator struct {

--- a/pipelines/topology/types_test.go
+++ b/pipelines/topology/types_test.go
@@ -1,6 +1,8 @@
 package topology
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -332,6 +334,258 @@ func TestDependency_Lookup(t *testing.T) {
 			}
 			if diff := cmp.Diff(build, testCase.expected); diff != "" {
 				t.Errorf("build: (-want got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoadCombined_TopologyDirMapping(t *testing.T) {
+	teamAPath := filepath.Join("testdata", "team-a", "topology.yaml")
+	teamBPath := filepath.Join("testdata", "team-b", "topology.yaml")
+
+	got, err := LoadCombined([]string{teamAPath, teamBPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantDirMap := map[string]string{
+		"Microsoft.Azure.ARO.HCP":           filepath.Join("testdata", "team-a"),
+		"Microsoft.Azure.ARO.HCP.Child":     filepath.Join("testdata", "team-a"),
+		"Microsoft.Azure.ARO.Classic":       filepath.Join("testdata", "team-b"),
+		"Microsoft.Azure.ARO.HCP.Extension": filepath.Join("testdata", "team-b"),
+	}
+
+	for serviceGroup, wantDir := range wantDirMap {
+		gotDir, err := got.GetTopologyDirForServiceGroup(serviceGroup)
+		if err != nil {
+			t.Errorf("unexpected error for %s: %v", serviceGroup, err)
+			continue
+		}
+		if gotDir != wantDir {
+			t.Errorf("for service group %s: want dir %q, got %q", serviceGroup, wantDir, gotDir)
+		}
+	}
+}
+
+func TestLoadCombined(t *testing.T) {
+	externalParentHCP := "Microsoft.Azure.ARO.HCP"
+	externalParentOther := "Microsoft.Azure.ARO.Other"
+
+	writeTempTopology := func(t *testing.T, content string) string {
+		t.Helper()
+		f, err := os.CreateTemp("", "topology-*.yaml")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %s", err)
+		}
+		t.Cleanup(func() {
+			if err := os.Remove(f.Name()); err != nil {
+				t.Errorf("failed to remove temp file: %v", err)
+			}
+		})
+		if _, err := f.WriteString(content); err != nil {
+			t.Fatalf("failed to write topology: %s", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close topology file: %s", err)
+		}
+		return f.Name()
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		topologies []string
+		expected   *Topology
+		err        bool
+	}{
+		{
+			name: "single topology",
+			topologies: []string{`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff`},
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "foo",
+						Purpose:      "stuff",
+					},
+				},
+			},
+		},
+		{
+			name: "two topologies with cross-dependencies",
+			topologies: []string{
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff
+- serviceGroup: Microsoft.Azure.ARO.Classic.Child
+  pipelinePath: baz
+  purpose: classic child
+  externalParent: Microsoft.Azure.ARO.Other`,
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.Other
+  pipelinePath: bar
+  purpose: other stuff
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: qux
+  purpose: hcp child
+  externalParent: Microsoft.Azure.ARO.HCP`,
+			},
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "foo",
+						Purpose:      "stuff",
+						Children: []Service{
+							{
+								ServiceGroup:   "Microsoft.Azure.ARO.HCP.Child",
+								PipelinePath:   "qux",
+								Purpose:        "hcp child",
+								ExternalParent: &externalParentHCP,
+							},
+						},
+					},
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.Other",
+						PipelinePath: "bar",
+						Purpose:      "other stuff",
+						Children: []Service{
+							{
+								ServiceGroup:   "Microsoft.Azure.ARO.Classic.Child",
+								PipelinePath:   "baz",
+								Purpose:        "classic child",
+								ExternalParent: &externalParentOther,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single topology with externalParent is not an error",
+			topologies: []string{`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: child
+  externalParent: Microsoft.Azure.ARO.HCP`},
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "foo",
+						Purpose:      "stuff",
+					},
+					{
+						ServiceGroup:   "Microsoft.Azure.ARO.HCP.Child",
+						PipelinePath:   "bar",
+						Purpose:        "child",
+						ExternalParent: func() *string { s := "Microsoft.Azure.ARO.HCP"; return &s }(),
+					},
+				},
+			},
+		},
+		{
+			name: "chained external parents across three topologies in reverse order",
+			topologies: []string{
+				// topology 3: C depends on B
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.B.C
+  pipelinePath: c.yaml
+  purpose: service c
+  externalParent: Microsoft.Azure.ARO.HCP.B`,
+				// topology 2: B depends on A
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.B
+  pipelinePath: b.yaml
+  purpose: service b
+  externalParent: Microsoft.Azure.ARO.HCP`,
+				// topology 1: A is the root
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: a.yaml
+  purpose: service a`,
+			},
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "a.yaml",
+						Purpose:      "service a",
+						Children: []Service{
+							{
+								ServiceGroup:   "Microsoft.Azure.ARO.HCP.B",
+								PipelinePath:   "b.yaml",
+								Purpose:        "service b",
+								ExternalParent: func() *string { s := "Microsoft.Azure.ARO.HCP"; return &s }(),
+								Children: []Service{
+									{
+										ServiceGroup:   "Microsoft.Azure.ARO.HCP.B.C",
+										PipelinePath:   "c.yaml",
+										Purpose:        "service c",
+										ExternalParent: func() *string { s := "Microsoft.Azure.ARO.HCP.B"; return &s }(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "errors when a nested child has externalParent set",
+			topologies: []string{`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff
+- serviceGroup: Microsoft.Azure.ARO.HCP.Parent
+  pipelinePath: bar
+  purpose: parent
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Parent.Child
+    pipelinePath: baz
+    purpose: child
+    externalParent: Microsoft.Azure.ARO.HCP`},
+			err: true,
+		},
+		{
+			name: "errors when external parent does not exist",
+			topologies: []string{
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff`,
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: child
+  externalParent: Microsoft.Azure.ARO.DoesNotExist`,
+			},
+			err: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			paths := make([]string, len(testCase.topologies))
+			for i, content := range testCase.topologies {
+				paths[i] = writeTempTopology(t, content)
+			}
+
+			got, err := LoadCombined(paths)
+			if err == nil && testCase.err {
+				t.Errorf("expected error, got none")
+			}
+			if err != nil && !testCase.err {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if testCase.expected != nil {
+				if diff := cmp.Diff(testCase.expected, &got.Topology); diff != "" {
+					t.Errorf("combined topology mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pipelines/topology/types_test.go
+++ b/pipelines/topology/types_test.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -332,6 +333,124 @@ func TestDependency_Lookup(t *testing.T) {
 			}
 			if diff := cmp.Diff(build, testCase.expected); diff != "" {
 				t.Errorf("build: (-want got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddChildTopology(t *testing.T) {
+	externalParent := "Microsoft.Azure.ARO.HCP"
+	for _, testCase := range []struct {
+		name     string
+		parent   string
+		child    string
+		expected *Topology
+		err      bool
+	}{
+		{
+			name: "successfully adds child to existing parent",
+			parent: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff`,
+			child: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: child stuff
+  externalParent: Microsoft.Azure.ARO.HCP
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Child.Grandchild
+    pipelinePath: baz
+    purpose: grandchild stuff`,
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "foo",
+						Purpose:      "stuff",
+						Children: []Service{
+							{
+								ServiceGroup:   "Microsoft.Azure.ARO.HCP.Child",
+								PipelinePath:   "bar",
+								Purpose:        "child stuff",
+								ExternalParent: &externalParent,
+								Children: []Service{
+									{
+										ServiceGroup: "Microsoft.Azure.ARO.HCP.Child.Grandchild",
+										PipelinePath: "baz",
+										Purpose:      "grandchild stuff",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: false,
+		},
+		{
+			name: "errors when external parent does not exist",
+			parent: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff`,
+			child: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: child stuff
+  externalParent: Microsoft.Azure.ARO.HCP.DoesNotExist`,
+			err: true,
+		},
+		{
+			name: "errors when a child service has externalParent set",
+			parent: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: stuff`,
+			child: `services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: child stuff
+  externalParent: Microsoft.Azure.ARO.HCP
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Child.Grandchild
+    pipelinePath: baz
+    purpose: grandchild stuff
+    externalParent: Microsoft.Azure.ARO.HCP`,
+			err: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var parentTopo Topology
+			if err := yaml.Unmarshal([]byte(testCase.parent), &parentTopo); err != nil {
+				t.Fatalf("failed to unmarshal parent: %s", err)
+			}
+			childFile, err := os.CreateTemp("", "child-topology-*.yaml")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %s", err)
+			}
+			defer func() {
+				if err := os.Remove(childFile.Name()); err != nil {
+					t.Errorf("failed to remove temp file: %v", err)
+				}
+			}()
+			if _, err := childFile.WriteString(testCase.child); err != nil {
+				t.Fatalf("failed to write child topology: %s", err)
+			}
+			if err := childFile.Close(); err != nil {
+				t.Fatalf("failed to close child topology file: %s", err)
+			}
+			err = parentTopo.AddChildTopology(childFile.Name())
+			if err == nil && testCase.err {
+				t.Errorf("expected error, got none")
+			}
+			if err != nil && !testCase.err {
+				t.Errorf("expected no error, got: %v", err)
+			}
+			if testCase.expected != nil {
+				if diff := cmp.Diff(testCase.expected, &parentTopo); diff != "" {
+					t.Errorf("combined topology mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This allows combining multiple topologies together for one entrypoint deployment.

Draft PR of approximately how this will be used (Needs to be cleaned up before merge): [Pull Request 15536279](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/15536279): Allowing child topology to add msft hcp service groups to entrypoint