### PR TITLE
prow-job-executor: bump monitoring timeout from 3h to 4h

### DIFF
--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -57,7 +57,7 @@ func DefaultExecuteOptions() *RawExecuteOptions {
 		Annotations:         make(map[string]string),
 		EnvironmentVars:     make(map[string]string),
 		PollInterval:        300 * time.Second,
-		Timeout:             3 * time.Hour,
+		Timeout:             4 * time.Hour,
 		GangwayURL:          defaultGangwayURL,
 		ProwURL:             defaultProwURL,
 		BaseRef:             defaultBaseRef,
@@ -371,7 +371,7 @@ func DefaultMonitorOptions() *RawMonitorOptions {
 	return &RawMonitorOptions{
 		RawProwTokenOptions: NewDefaultRawProwTokenOptions(),
 		PollInterval:        300 * time.Second,
-		Timeout:             3 * time.Hour,
+		Timeout:             4 * time.Hour,
 		GangwayURL:          defaultGangwayURL,
 		ProwURL:             defaultProwURL,
 	}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-731

### What

Bump the default `Timeout` in `prowjobexecutor` from 3 hours to 4 hours, for both `execute` and `monitor` commands.

### Why

The EV2 `MaxExecutionTime` for prow job steps is `PT4H` (set in `sdp-pipelines/tooling/pkg/types/pipeline/prow.go:122`), but the executor's internal monitoring timeout defaults to 3 hours. When a Prow job takes between 3-4 hours, the executor gives up and reports failure:

```
job monitoring timed out after 3h0m0s - job 63d2bc3b-3666-426d-9e1e-c145153cbe82 may still be running (unable to retrieve job status)
```

The job actually succeeded — it just took slightly over 3 hours. The executor timeout should match the EV2 window.

### Changes

- `options.go:60`: `DefaultExecuteOptions` timeout `3 * time.Hour` -> `4 * time.Hour`
- `options.go:374`: `DefaultMonitorOptions` timeout `3 * time.Hour` -> `4 * time.Hour`

### Testing

`go build ./tools/prow-job-executor/...` passes.