### PR TITLE
Add optional commit field to ProwJobStep

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -645,7 +645,8 @@ type ProwJobStep struct {
 	TokenKeyvault string `json:"tokenKeyvault"`
 	TokenSecret   string `json:"tokenSecret"`
 	JobName       string `json:"jobName"`
-	GatePromotion string `json:"gatePromotion"` // string-encoded boolean, passed to command as a flag
+	GatePromotion string `json:"gatePromotion"`    // string-encoded boolean, passed to command as a flag
+	Commit        string `json:"commit,omitempty"` // optional source commit SHA to pin the Prow job to
 	DryRun        DryRun `json:"dryRun,omitempty"`
 
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -630,6 +630,9 @@
             "gatePromotion": {
               "type": "string"
             },
+            "commit": {
+              "type": "string"
+            },
             "identityFrom": {
               "$ref": "#/definitions/input"
             },


### PR DESCRIPTION
Why?
Classic E2E pipeline run Prow jobs against ARO-RP master HEAD, which can diverge from the RP version deployed in the environment. This causes test failures when the E2E test expects features or flags that the deployed RP doesn't have yet

What?
Add an optional `commit` field to `ProwJobStep` in the pipeline types and JSON schema. sdp-pipelines will use this value as `--base-sha` in the prowjobexecutor, allowing Prow to check out a specific source commit instead of HEAD