### PR TITLE
AROSLSRE-779: Add OWNERS file for Prow-based code ownership

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - stevekuznetsov
+  - janboll
+  - geoberle
+  - rachelvweber
+  - weinong
+  - abiduke612
+  - raelga
+  - roivaz
+reviewers:
+  - gouthamMN
+  - changjonathanc


### PR DESCRIPTION
## Summary
- Add OWNERS file for Prow-based code ownership
- Approvers: contributors with 6+ commits in the last 12 months
- Reviewers: contributors with exactly 5 commits in the last 12 months

## JIRA
[AROSLSRE-779](https://redhat.atlassian.net/browse/AROSLSRE-779)

## Test plan
- [x] Verify OWNERS file is valid YAML
- [x] Verify GitHub usernames resolve correctly
- [ ] Confirm Prow picks up the OWNERS file