### PR TITLE
chore: Add optional MdsdConfigFile field to LogsStep

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -304,6 +304,7 @@ type LogsStep struct {
 	MonikerDefaultRegion Value            `json:"monikerDefaultRegion,omitempty"`
 	Database             Value            `json:"database,omitempty"`
 	EventSources         map[string]Event `json:"eventSources,omitempty"`
+	MdsdConfigFile       *Value           `json:"mdsdConfigFile,omitempty"`
 }
 
 type Event struct {
@@ -321,6 +322,9 @@ func (s *LogsStep) RequiredInputs() []StepDependency {
 		if val.Input != nil {
 			deps = append(deps, val.Input.StepDependency)
 		}
+	}
+	if s.MdsdConfigFile != nil && s.MdsdConfigFile.Input != nil {
+		deps = append(deps, s.MdsdConfigFile.Input.StepDependency)
 	}
 	slices.SortFunc(deps, SortDependencies)
 	deps = slices.Compact(deps)

--- a/pipelines/types/common_test.go
+++ b/pipelines/types/common_test.go
@@ -152,6 +152,7 @@ func TestRequiredInputs(t *testing.T) {
 			input: &LogsStep{
 				RolloutKind:     "FluentBit",
 				TypeName:        Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				MdsdConfigFile:  &Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step1"}}},
 				SecretKeyVault:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
 				SecretName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
 				Environment:     Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
@@ -167,6 +168,7 @@ func TestRequiredInputs(t *testing.T) {
 			},
 			expected: []StepDependency{
 				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step1"},
 				{ResourceGroup: "rg", Step: "step2"},
 				{ResourceGroup: "rg", Step: "step3"},
 				{ResourceGroup: "rg", Step: "step4"},

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -1169,6 +1169,9 @@
             "database": {
               "$ref": "#/definitions/value"
             },
+            "mdsdConfigFile": {
+              "$ref": "#/definitions/value"
+            },
             "eventSources": {
               "type": "object",
               "description": "A map of event configurations where keys represent the fluent bit tag and values are their corresponding Geneva Event config. Refer to https://eng.ms/docs/products/geneva/collect/instrument/linux/fluentd for details",


### PR DESCRIPTION
Allows downstream tooling to read a checked-in XML file as the Geneva monitoring agent config.

Why:
https://redhat.atlassian.net/browse/AROSLSRE-716