### PR TITLE
Add optional repo and baseRef fields to ProwJobStep

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -649,8 +649,10 @@ type ProwJobStep struct {
 	TokenKeyvault string `json:"tokenKeyvault"`
 	TokenSecret   string `json:"tokenSecret"`
 	JobName       string `json:"jobName"`
-	GatePromotion string `json:"gatePromotion"`    // string-encoded boolean, passed to command as a flag
-	Commit        string `json:"commit,omitempty"` // optional source commit SHA to pin the Prow job to
+	GatePromotion string `json:"gatePromotion"`     // string-encoded boolean, passed to command as a flag
+	Commit        string `json:"commit,omitempty"`  // optional source commit SHA to pin the Prow job to
+	Repo          string `json:"repo,omitempty"`    // optional GitHub repo name override (default: ARO-HCP)
+	BaseRef       string `json:"baseRef,omitempty"` // optional Git base ref override (default: main)
 	DryRun        DryRun `json:"dryRun,omitempty"`
 
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -633,6 +633,12 @@
             "commit": {
               "type": "string"
             },
+            "repo": {
+              "type": "string"
+            },
+            "baseRef": {
+              "type": "string"
+            },
             "identityFrom": {
               "$ref": "#/definitions/input"
             },


### PR DESCRIPTION
## Why

When using the `commit` field to pin a ProwJob to a specific source commit, the prowjobexecutor defaults to `ARO-HCP` repo on `main` branch. Classic E2E jobs target `ARO-RP` on `master`, so the repo and base ref need to be overridable per step

## What

Add optional `repo` and `baseRef` fields to `ProwJobStep` in the pipeline types and JSON schema. When set, sdp-pipelines will pass them as `--repo` and `--base-ref` to prowjobexecutor, overriding the defaults.