### PR TITLE
Allow image mirror from public registry

### DIFF
--- a/config/testdata/pipelines/pipeline.yaml
+++ b/config/testdata/pipelines/pipeline.yaml
@@ -392,6 +392,19 @@ resourceGroups:
       adoProject: '{{ .imageMirror.adoProject }}'
       artifactName: '{{ .imageMirror.artifactName }}'
       buildId: '{{ .imageMirror.buildId }}'
+    - name: image-mirror-public-registry
+      action: ImageMirror
+      targetACR:
+        value: targetACR
+      sourceRegistry:
+        value: mcr.microsoft.com
+      repository:
+        value: repository
+      digest:
+        value: digest
+      publicSource: true
+      shellIdentity:
+        value: shellIdentity
     - name: pav2
       action: Pav2
       operation: All

--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -390,6 +390,19 @@ resourceGroups:
       adoProject: '{{ .imageMirror.adoProject }}'
       artifactName: '{{ .imageMirror.artifactName }}'
       buildId: '{{ .imageMirror.buildId }}'
+    - name: image-mirror-public-registry
+      action: ImageMirror
+      targetACR:
+        value: targetACR
+      sourceRegistry:
+        value: mcr.microsoft.com
+      repository:
+        value: repository
+      digest:
+        value: digest
+      publicSource: true
+      shellIdentity:
+        value: shellIdentity
     - name: pav2
       action: Pav2
       operation: All

--- a/pipelines/types/common_test.go
+++ b/pipelines/types/common_test.go
@@ -290,6 +290,7 @@ func TestIsWellFormedOverInputs(t *testing.T) {
 		{in: &ResourceProviderRegistrationStep{}, expected: true},
 		{in: &ImageMirrorStep{}, expected: true},
 		{in: &ImageMirrorStep{CopyFrom: "oci-layout", ADOProject: "project", ArtifactName: "artifact", BuildID: "buildId"}, expected: true},
+		{in: &ImageMirrorStep{PublicSource: true}, expected: true},
 		{in: &LogsStep{}, expected: true},
 		{in: &FeatureRegistrationStep{}, expected: true},
 		{in: &ProviderFeatureRegistrationStep{}, expected: true},

--- a/pipelines/types/imagemirror.go
+++ b/pipelines/types/imagemirror.go
@@ -36,6 +36,7 @@ type ImageMirrorStep struct {
 	Repository            Value  `json:"repository,omitempty"`
 	Digest                Value  `json:"digest,omitempty"`
 	CopyFrom              string `json:"copyFrom,omitempty"`
+	PublicSource          bool   `json:"publicSource,omitempty"`
 	ImageFilePath         Value  `json:"imageFilePath,omitempty"` // optional, if path is same as pipeline.yaml
 	ImageTarFileName      Value  `json:"imageTarFileName,omitempty"`
 	ImageMetadataFileName Value  `json:"imageMetadataFileName,omitempty"`
@@ -79,9 +80,11 @@ func ResolveImageMirrorStep(input ImageMirrorStep, scriptFile string) (*ShellSte
 		variables = append(variables, namedVariable("IMAGE_METADATA_FILE_NAME", input.ImageMetadataFileName))
 	default:
 		variables = append(variables, namedVariable("SOURCE_REGISTRY", input.SourceRegistry))
-		variables = append(variables, namedVariable("PULL_SECRET_KV", input.PullSecretKeyVault))
-		variables = append(variables, namedVariable("PULL_SECRET", input.PullSecretName))
 		variables = append(variables, namedVariable("DIGEST", input.Digest))
+		if !input.PublicSource {
+			variables = append(variables, namedVariable("PULL_SECRET_KV", input.PullSecretKeyVault))
+			variables = append(variables, namedVariable("PULL_SECRET", input.PullSecretName))
+		}
 	}
 
 	return &ShellStep{

--- a/pipelines/types/imagemirror_test.go
+++ b/pipelines/types/imagemirror_test.go
@@ -77,6 +77,22 @@ func TestResolveImageMirrorStep(t *testing.T) {
 			},
 			scriptFile: "/path/to/script.sh",
 		},
+		{
+			name: "image-mirror-step-with-public-registry",
+			input: ImageMirrorStep{
+				StepMeta: StepMeta{
+					Name:   "image-mirror-step",
+					Action: "ImageMirror",
+				},
+				TargetACR:      Value{Value: "myacr.azurecr.io"},
+				SourceRegistry: Value{Value: "mcr.microsoft.com"},
+				Repository:     Value{Value: "nginx"},
+				Digest:         Value{Value: "sha256:123456"},
+				PublicSource:   true,
+				ShellIdentity:  Value{Value: "my-identity"},
+			},
+			scriptFile: "/path/to/script.sh",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -35,9 +35,6 @@ copyImageFromRegistry() {
 
     # validate
     REQUIRED_VARS=("REPOSITORY" "DIGEST")
-    if [[ -n "${PULL_SECRET_KV:-}" || -n "${PULL_SECRET:-}" ]]; then
-        REQUIRED_VARS+=("PULL_SECRET_KV" "PULL_SECRET")
-    fi
     for VAR in "${REQUIRED_VARS[@]}"; do
         if [ -z "${!VAR}" ]; then
             echo "Error: Environment variable $VAR is not set."

--- a/pipelines/types/on-demand.sh
+++ b/pipelines/types/on-demand.sh
@@ -34,7 +34,10 @@ copyImageFromRegistry() {
     fi
 
     # validate
-    REQUIRED_VARS=("PULL_SECRET_KV" "PULL_SECRET" "REPOSITORY" "DIGEST")
+    REQUIRED_VARS=("REPOSITORY" "DIGEST")
+    if [[ -n "${PULL_SECRET_KV:-}" || -n "${PULL_SECRET:-}" ]]; then
+        REQUIRED_VARS+=("PULL_SECRET_KV" "PULL_SECRET")
+    fi
     for VAR in "${REQUIRED_VARS[@]}"; do
         if [ -z "${!VAR}" ]; then
             echo "Error: Environment variable $VAR is not set."
@@ -51,24 +54,28 @@ copyImageFromRegistry() {
     mkdir -p "${ORAS_CACHE}"
     trap 'rm -rf ${TMP_DIR}' EXIT
 
-    # Check if source registry should use oc login , ENV variable is set in Release job.
-    IS_CI_REGISTRY=false
-    if [[ -n "${USE_OC_LOGIN_REGISTRIES:-}" ]]; then
-        echo "Checking USE_OC_LOGIN_REGISTRIES: ${USE_OC_LOGIN_REGISTRIES}"
-        for registry in ${USE_OC_LOGIN_REGISTRIES}; do
-            if [[ "${SOURCE_REGISTRY}" == "${registry}" ]]; then
-                IS_CI_REGISTRY=true
-                break
-            fi
-        done
-    fi
-
-    if [[ "${IS_CI_REGISTRY}" == "true" ]]; then
-        echo "Setting up registry authentication for CI source registry."
-        oc registry login --to "${AUTH_JSON}"
+    if [[ -z "${PULL_SECRET_KV:-}" && -z "${PULL_SECRET:-}" ]]; then
+        echo "No pull secret configured: pulling from public source registry."
     else
-        echo "Fetch pull secret for source registry ${SOURCE_REGISTRY} from ${PULL_SECRET_KV} KV."
-        az keyvault secret download --vault-name "${PULL_SECRET_KV}" --name "${PULL_SECRET}" -e base64 --file "${AUTH_JSON}"
+        # Check if source registry should use oc login , ENV variable is set in Release job.
+        IS_CI_REGISTRY=false
+        if [[ -n "${USE_OC_LOGIN_REGISTRIES:-}" ]]; then
+            echo "Checking USE_OC_LOGIN_REGISTRIES: ${USE_OC_LOGIN_REGISTRIES}"
+            for registry in ${USE_OC_LOGIN_REGISTRIES}; do
+                if [[ "${SOURCE_REGISTRY}" == "${registry}" ]]; then
+                    IS_CI_REGISTRY=true
+                    break
+                fi
+            done
+        fi
+
+        if [[ "${IS_CI_REGISTRY}" == "true" ]]; then
+            echo "Setting up registry authentication for CI source registry."
+            oc registry login --to "${AUTH_JSON}"
+        else
+            echo "Fetch pull secret for source registry ${SOURCE_REGISTRY} from ${PULL_SECRET_KV} KV."
+            az keyvault secret download --vault-name "${PULL_SECRET_KV}" --name "${PULL_SECRET}" -e base64 --file "${AUTH_JSON}"
+        fi
     fi
 
     # ACR login to target registry

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -1307,6 +1307,9 @@
             "copyFrom": {
               "const": "oci-layout"
             },
+            "publicSource": {
+              "type": "boolean"
+            },
             "imageFilePath": {
               "$ref": "#/definitions/value"
             },
@@ -1359,6 +1362,21 @@
                 "artifactName",
                 "buildId"
               ]
+            },
+            {
+              "required": [
+                "targetACR",
+                "sourceRegistry",
+                "repository",
+                "digest",
+                "publicSource",
+                "shellIdentity"
+              ],
+              "properties": {
+                "publicSource": {
+                  "const": true
+                }
+              }
             }
           ]
         }

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -405,6 +405,24 @@ resourceGroups:
     sourceRegistry: {}
     targetACR:
       value: targetACR
+  - action: ImageMirror
+    digest:
+      value: digest
+    imageFilePath: {}
+    imageMetadataFileName: {}
+    imageTarFileName: {}
+    name: image-mirror-public-registry
+    publicSource: true
+    pullSecretKeyVault: {}
+    pullSecretName: {}
+    repository:
+      value: repository
+    shellIdentity:
+      value: shellIdentity
+    sourceRegistry:
+      value: mcr.microsoft.com
+    targetACR:
+      value: targetACR
   - action: Pav2
     name: pav2
     operation: All

--- a/pipelines/types/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_deps.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_deps.yaml
@@ -17,9 +17,9 @@ variables:
   value: nginx
 - name: SOURCE_REGISTRY
   value: docker.io
+- name: DIGEST
+  value: sha256:123456
 - name: PULL_SECRET_KV
   value: my-keyvault
 - name: PULL_SECRET
   value: my-pull-secret
-- name: DIGEST
-  value: sha256:123456

--- a/pipelines/types/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_public_registry.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestResolveImageMirrorStep_image_mirror_step_with_public_registry.yaml
@@ -13,10 +13,6 @@ variables:
 - name: REPOSITORY
   value: nginx
 - name: SOURCE_REGISTRY
-  value: docker.io
+  value: mcr.microsoft.com
 - name: DIGEST
   value: sha256:123456
-- name: PULL_SECRET_KV
-  value: my-keyvault
-- name: PULL_SECRET
-  value: my-pull-secret


### PR DESCRIPTION
We are currently require all mirror image step to have secret. But since there are cases where we mirror image from a public mcr ( for example mcr.microsoft.com/geneva/distroless/mdsd for metrics). this add the optional field in image mirror step that doesn't require pull secret