### PR TITLE
Updating prow job dryRun variable to be a bool again

### DIFF
--- a/pipelines/testdata/config.yaml
+++ b/pipelines/testdata/config.yaml
@@ -38,6 +38,7 @@ defaults:
   availabilityZoneCount: {{ .ev2.availabilityZoneCount }}
   enableOptionalStep: false
   e2e:
+    enabled: true
     prow:
       globalKeyVaultTokenSecret: "prow-token"
     regionTest:

--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -533,9 +533,21 @@ resourceGroups:
     action: ProwJob
     tokenKeyvault: "{{ .global.keyVault.name }}.vault.azure.net"
     dryRun:
-      variables:
-      - name: DRY_RUN
-        value: "true"
+      configRef: e2e.enabled
+    tokenSecret: "{{ .e2e.prow.globalKeyVaultTokenSecret }}"
+    jobName: "{{ .e2e.regionTest.prowJobName }}"
+    gatePromotion: "{{ .e2e.regionTest.gatePromotion }}"
+    identityFrom:
+      resourceGroup: regional
+      step: deploy
+      name: whatever
+    validation:
+    - Internal
+  - name: e2e2
+    action: ProwJob
+    tokenKeyvault: "{{ .global.keyVault.name }}.vault.azure.net"
+    dryRun:
+      value: true
     tokenSecret: "{{ .e2e.prow.globalKeyVaultTokenSecret }}"
     jobName: "{{ .e2e.regionTest.prowJobName }}"
     gatePromotion: "{{ .e2e.regionTest.gatePromotion }}"

--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -653,7 +653,7 @@ type ProwJobStep struct {
 	Commit        string `json:"commit,omitempty"`  // optional source commit SHA to pin the Prow job to
 	Repo          string `json:"repo,omitempty"`    // optional GitHub repo name override (default: ARO-HCP)
 	BaseRef       string `json:"baseRef,omitempty"` // optional Git base ref override (default: main)
-	DryRun        DryRun `json:"dryRun,omitempty"`
+	DryRun        Value  `json:"dryRun,omitempty"`
 
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.
 	IdentityFrom Input `json:"identityFrom,omitempty"`
@@ -664,12 +664,9 @@ func (s *ProwJobStep) Description() string {
 }
 
 func (s *ProwJobStep) RequiredInputs() []StepDependency {
-
 	var deps []StepDependency
-	for _, val := range s.DryRun.Variables {
-		if val.Input != nil {
-			deps = append(deps, val.Input.StepDependency)
-		}
+	if s.DryRun.Input != nil {
+		deps = append(deps, s.DryRun.Input.StepDependency)
 	}
 	for _, val := range []Input{s.IdentityFrom} {
 		deps = append(deps, val.StepDependency)

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -643,19 +643,7 @@
               "$ref": "#/definitions/input"
             },
             "dryRun": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "command": {
-                  "type": "string"
-                },
-                "variables": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/variable"
-                  }
-                }
-              }
+              "$ref": "#/definitions/value"
             }
           },
           "required": [

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -556,9 +556,21 @@ resourceGroups:
     - Internal
   - action: ProwJob
     dryRun:
-      variables:
-      - name: DRY_RUN
-        value: "true"
+      configRef: e2e.enabled
+    gatePromotion: "true"
+    identityFrom:
+      name: whatever
+      resourceGroup: regional
+      step: deploy
+    jobName: test-me
+    name: e2e2
+    tokenKeyvault: arohcpint-global.vault.azure.net
+    tokenSecret: prow-token
+    validation:
+    - Internal
+  - action: ProwJob
+    dryRun:
+      value: true
     gatePromotion: "true"
     identityFrom:
       name: whatever


### PR DESCRIPTION
Classic prow tests don't work in fairfax. Ev2 disallows adding execution constraints to validation steps, so I can't exclude them all together. The prow job executor tool already has a dryrun option. It just needs to be plumbed through. This change will require update-testdata to be run in sdp-pipelines but it should be otherwise compatible

Previous history on this in case this looks familiar:
1. This variable used to be a DryRun-type
2. The old DryRun variable of type DryRun was removed from the prow job step when the prow job executor was created
3. The pipelines in ARO-HCP had the DryRun variable removed, but the ones in sdp-pipelines did not
4. I added the DryRun variable of type bool to this step
5. Things went poorly when that version of ARO-Tools got to sdp-pipelines because the pipelines still had the old version of the variable
6. The variable in here was changed back to be of type DryRun to fix the failures
7. The DryRun variables were removed from the prow job steps in sdp-pipelines
8. I'm trying this again