### PR TITLE
config/types: support slice indexing in GetByPath

### DIFF
--- a/config/types/configuration.go
+++ b/config/types/configuration.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -26,19 +27,56 @@ func (e MissingKeyError) Error() string {
 	return fmt.Sprintf("configuration%s: key %s not found", e.Path, e.Key)
 }
 
+// IndexOutOfRangeError is returned by GetByPath when a numeric key is used
+// to index into a slice but falls outside the bounds of that slice.
+type IndexOutOfRangeError struct {
+	Path   string
+	Index  int
+	Length int
+}
+
+func (e IndexOutOfRangeError) Error() string {
+	return fmt.Sprintf("configuration%s: index %d out of range [0, %d)", e.Path, e.Index, e.Length)
+}
+
+// GetByPath navigates the configuration tree following the dot-separated keys
+// in path and returns the value at that location.
+//
+// Keys are interpreted in two ways depending on the type of the current node:
+//   - For map nodes (map[string]any), the key is used as a literal map key.
+//   - For slice nodes ([]any), the key must be a non-negative integer literal
+//     that is used as the index into the slice (e.g. "containers.0.image").
+//
+// Errors:
+//   - MissingKeyError when a map key does not exist.
+//   - IndexOutOfRangeError when a slice index is outside the slice bounds.
+//   - A plain error when a slice is reached but the next key is not a valid
+//     non-negative integer, or when the current node is neither a map nor a
+//     slice but more keys remain.
 func (v Configuration) GetByPath(path string) (any, error) {
 	keys := strings.Split(path, ".")
 	var current any = map[string]any(v)
 	var currentPath string
 
 	for _, key := range keys {
-		if m, ok := current.(map[string]any); ok {
-			current, ok = m[key]
+		switch typed := current.(type) {
+		case map[string]any:
+			next, ok := typed[key]
 			if !ok {
 				return nil, &MissingKeyError{Path: currentPath, Key: key}
 			}
-		} else {
-			return nil, fmt.Errorf("configuration%s: expected nested map, found %T; cannot index with %s", currentPath, current, key)
+			current = next
+		case []any:
+			idx, err := strconv.Atoi(key)
+			if err != nil {
+				return nil, fmt.Errorf("configuration%s: expected non-negative integer to index slice, got %q", currentPath, key)
+			}
+			if idx < 0 || idx >= len(typed) {
+				return nil, &IndexOutOfRangeError{Path: currentPath, Index: idx, Length: len(typed)}
+			}
+			current = typed[idx]
+		default:
+			return nil, fmt.Errorf("configuration%s: expected nested map or slice, found %T; cannot index with %s", currentPath, current, key)
 		}
 		currentPath += "[" + key + "]"
 	}

--- a/config/types/configuration_test.go
+++ b/config/types/configuration_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -110,6 +111,151 @@ func TestResolveSchemaPath(t *testing.T) {
 
 			if expected != actual {
 				t.Errorf("Expected %q, got %q", expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetByPathSlices(t *testing.T) {
+	cfg := Configuration{
+		"scalar": "hello",
+		"nested": map[string]any{
+			"inner":  "world",
+			"number": 42,
+		},
+		"items": []any{
+			"first",
+			"second",
+			"third",
+		},
+		"objects": []any{
+			map[string]any{
+				"name":  "alpha",
+				"value": 1,
+			},
+			map[string]any{
+				"name":  "beta",
+				"value": 2,
+			},
+		},
+		"matrix": []any{
+			[]any{"a", "b"},
+			[]any{"c", "d"},
+		},
+		"acr": map[string]any{
+			"extraAllowedRegistries": []any{
+				"registry.connect.redhat.com",
+				"registry.redhat.io",
+				"quay.io/redhat-user-workloads",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    any
+		wantErr bool
+		// errIs lets us assert a particular sentinel error type.
+		// Leave nil to skip the check.
+		errIs func(error) bool
+	}{
+		{
+			name: "top-level scalar",
+			path: "scalar",
+			want: "hello",
+		},
+		{
+			name: "nested map key",
+			path: "nested.inner",
+			want: "world",
+		},
+		{
+			name: "slice index into top-level slice",
+			path: "items.0",
+			want: "first",
+		},
+		{
+			name: "slice index, last element",
+			path: "items.2",
+			want: "third",
+		},
+		{
+			name: "slice index into slice of maps then map key",
+			path: "objects.1.name",
+			want: "beta",
+		},
+		{
+			name: "nested slice of slices",
+			path: "matrix.1.0",
+			want: "c",
+		},
+		{
+			name: "realistic: map -> slice index (image-registry-policy shape)",
+			path: "acr.extraAllowedRegistries.0",
+			want: "registry.connect.redhat.com",
+		},
+		{
+			name:    "missing top-level key",
+			path:    "doesNotExist",
+			wantErr: true,
+			errIs: func(err error) bool {
+				_, ok := err.(*MissingKeyError)
+				return ok
+			},
+		},
+		{
+			name:    "slice index out of range",
+			path:    "items.5",
+			wantErr: true,
+			errIs: func(err error) bool {
+				_, ok := err.(*IndexOutOfRangeError)
+				return ok
+			},
+		},
+		{
+			name:    "negative slice index",
+			path:    "items.-1",
+			wantErr: true,
+			errIs: func(err error) bool {
+				_, ok := err.(*IndexOutOfRangeError)
+				return ok
+			},
+		},
+		{
+			name:    "non-numeric key applied to slice",
+			path:    "items.first",
+			wantErr: true,
+		},
+		{
+			name:    "navigating into a scalar",
+			path:    "scalar.x",
+			wantErr: true,
+		},
+		{
+			name: "trailing slice returned whole",
+			path: "items",
+			want: []any{"first", "second", "third"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cfg.GetByPath(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for path %q, got nil (value=%v)", tt.path, got)
+				}
+				if tt.errIs != nil && !tt.errIs(err) {
+					t.Fatalf("error type mismatch for path %q: got %T (%v)", tt.path, err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for path %q: %v", tt.path, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("path %q: got %#v, want %#v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -64,7 +64,7 @@ func TestGetByPath(t *testing.T) {
 				},
 			},
 			path: "parent.key.nested",
-			err:  "configuration[parent][key]: expected nested map, found string; cannot index with nested",
+			err:  "configuration[parent][key]: expected nested map or slice, found string; cannot index with nested",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Teach `Configuration.GetByPath` to navigate slice (`[]any`) nodes by interpreting the next dot-segment as a non-negative integer index. Map navigation is unchanged.

After this change, a config reference like `imageRegistryPolicy.extraAllowedRegistries.0` resolves to the first element of that slice, matching the existing dot-path conventions for map-valued configuration.

## Why

Configuration values can be slices today, but `GetByPath` could only return a whole slice as an opaque value — there was no way to address an individual element. That blocks downstream tooling (notably the sdp-pipelines dunder rendering pipeline) from producing per-index placeholder references for list-valued configuration during ARO-HCP Ev2 manifest generation.

A list-valued field that uses Go ` + "`{{ range }}`" + ` in a Helm values.yaml currently has no working dunder representation: the build-time mapping collapses the entire slice to a single scalar placeholder, and ` + "`text/template`" + ` then fails with ` + "`range can't iterate over <string>`" + ` (e.g. https://github.com/Azure/ARO-HCP/pull/4690 hitting `__imageRegistryPolicy.extraAllowedRegistries__`).

This PR is the first of two changes that, together, fix that — it unblocks a sdp-pipelines change that emits per-index dunder placeholders (`__path.0__`, `__path.1__`, ...) and resolves them through `GetByPath`. That second PR will land separately in `Azure/sdp-pipelines` once this is merged and tagged.

## Behaviour

| Path                              | Before              | After                                          |
|-----------------------------------|---------------------|------------------------------------------------|
| `items` (slice node)              | returns whole `[]any` | returns whole `[]any` (unchanged)            |
| `items.0`                         | error               | returns element 0                              |
| `items.5` (len 3)                 | error               | `*IndexOutOfRangeError`                        |
| `items.foo`                       | error               | error: "expected non-negative integer..."      |
| `nested.key.deep` (deep map walk) | unchanged           | unchanged                                      |

A new `IndexOutOfRangeError` sentinel lets callers distinguish out-of-bounds from other failures without string matching, in the same shape as the existing `MissingKeyError`. The fall-through error wording changes from "expected nested map" to "expected nested map or slice" to accurately describe the new capability — one existing test that exact-matched that string was updated.

## Tests

- `config/types.TestGetByPathSlices` (new, 13 cases): top-level slice index, last element, slice-of-map, slice-of-slice, the realistic image-registry-policy shape, and three error paths (missing key, out-of-range, non-numeric slice key).
- `config.TestGetByPath` (existing, 4 cases): error-string expectation updated; otherwise unchanged.
- `go vet ./...` clean.

## Related

- Tracked in [AROSLSRE-913](https://issues.redhat.com/browse/AROSLSRE-913)
- Companion sdp-pipelines change to follow once this is merged.
- Mitigates a class of failures previously worked around via revert at https://github.com/Azure/ARO-HCP/pull/5357.