### PR TITLE
fix(helm): return dry-run errors before release cleanup

### DIFF
--- a/tools/helm/diagnostics_test.go
+++ b/tools/helm/diagnostics_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -203,5 +204,15 @@ func evaluateResourcesHelper(filename string) func(*testing.T) {
 		}
 
 		testutil.CompareWithFixture(t, results)
+	}
+}
+
+func TestReleaserToV1ReleaseNil(t *testing.T) {
+	_, err := releaserToV1Release(nil)
+	if err == nil {
+		t.Fatal("releaserToV1Release(nil) returned nil error")
+	}
+	if !errors.Is(err, ErrNilHelmReleaseResult) {
+		t.Fatalf("releaserToV1Release(nil) error = %q, want ErrNilHelmReleaseResult", err)
 	}
 }

--- a/tools/helm/options.go
+++ b/tools/helm/options.go
@@ -42,6 +42,9 @@ import (
 	"github.com/Azure/ARO-Tools/tools/cmdutils"
 )
 
+// ErrNilHelmReleaseResult is returned when Helm reports success without a release object.
+var ErrNilHelmReleaseResult = errors.New("helm release result is nil")
+
 func DefaultOptions() *RawOptions {
 	return &RawOptions{
 		Timeout: 5 * time.Minute,
@@ -290,6 +293,7 @@ func (opts *Options) Deploy(ctx context.Context) error {
 			releaser, releaseErr := runHelmUpgrade(ctx, logger, opts)
 			if releaseErr != nil {
 				logger.Error(releaseErr, "Failed to dry-run the Helm release.")
+				return fmt.Errorf("failed to dry-run Helm release: %w", releaseErr)
 			}
 			release, err := releaserToV1Release(releaser)
 			if err != nil {
@@ -310,6 +314,7 @@ func (opts *Options) Deploy(ctx context.Context) error {
 	releaser, releaseErr := runHelmUpgrade(ctx, logger, opts)
 	if releaseErr != nil {
 		logger.Error(releaseErr, "Failed to roll out the Helm release.")
+		return fmt.Errorf("failed to roll out Helm release: %w", releaseErr)
 	}
 	release, err := releaserToV1Release(releaser)
 	if err != nil {
@@ -318,9 +323,6 @@ func (opts *Options) Deploy(ctx context.Context) error {
 	logger.Info("Finished deploying Helm release.")
 
 	if opts.DryRun {
-		if releaseErr != nil {
-			return fmt.Errorf("failed to create a dry-run Helm release: %w", releaseErr)
-		}
 		logger.Info("Validating Helm release contents for dry-run.")
 		if err := validateHelmResources(ctx, logger, opts, release); err != nil {
 			return fmt.Errorf("failed to validate Helm release contents for dry-run: %w", err)
@@ -452,12 +454,20 @@ func runDiagnostics(ctx context.Context, logger logr.Logger, opts *Options, depl
 		return fmt.Errorf("failed to convert releaser to v1 release: %w", err)
 	}
 
+	hasInfo := release.Info != nil
+	var status any = "<missing>"
+	description := "<missing>"
+	if hasInfo {
+		status = release.Info.Status
+		description = release.Info.Description
+	}
 	logger.Info(
 		"Determined release status.",
 		"release", release.Name,
 		"namespace", release.Namespace,
-		"status", release.Info.Status,
-		"description", release.Info.Description,
+		"hasInfo", hasInfo,
+		"status", status,
+		"description", description,
 		"values", release.Config,
 	)
 
@@ -637,7 +647,7 @@ func releaserToV1Release(rel helmrelease.Releaser) (*helmreleasev1.Release, erro
 	case *helmreleasev1.Release:
 		return r, nil
 	case nil:
-		return nil, nil
+		return nil, ErrNilHelmReleaseResult
 	default:
 		return nil, fmt.Errorf("unsupported release type: %T", rel)
 	}


### PR DESCRIPTION
## Summary

Fix `helmdeploy` panic when the preliminary `helm upgrade --dry-run` fails before returning a release object.

This is the failure mode from ARO-HCP Ev2 fleet deployment logs:

```text
Failed to dry-run the Helm release: another operation (install/upgrade/rollback) is in progress
panic: runtime error: invalid memory address or nil pointer dereference
... removeOldFieldManager(... release *Release)
```

The deployer should return the original Helm error instead of trying to remove managed fields from a nil release.

## Changes

- Return immediately when the pre-deploy dry-run fails, preserving the original Helm error.
- Return rollout errors before converting a nil release, while still running diagnostics for real rollout failures.
- Treat nil Helm releases as explicit conversion errors.
- Add a regression test for nil release conversion.

## Validation

- `go test ./tools/helm`



Jira: [AROSLSRE-974](https://redhat.atlassian.net/browse/AROSLSRE-974) (sub-task of [AROSLSRE-975](https://redhat.atlassian.net/browse/AROSLSRE-975))



