### PR TITLE
Add RunGenevaAction pipeline step type

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -533,6 +533,40 @@ func (s *HelmStep) RequiredInputs() []StepDependency {
 	return deps
 }
 
+const StepActionRunGenevaAction = "RunGenevaAction"
+
+type RunGenevaActionStep struct {
+	StepMeta          `json:",inline"`
+	SecretKeyVault    Value            `json:"secretKeyVault,omitempty"`
+	SecretName        Value            `json:"secretName,omitempty"`
+	GAExtensionName   Value            `json:"gaExtensionName,omitempty"`
+	GAEndpoint        Value            `json:"gaEndpoint,omitempty"`
+	GAOperationId     Value            `json:"gaOperationId,omitempty"`
+	MaxExecutionTime  string           `json:"maxExecutionTime,omitempty"`
+	PayloadProperties map[string]Value `json:"payloadProperties,omitempty"`
+}
+
+func (s *RunGenevaActionStep) Description() string {
+	return fmt.Sprintf("Step %s\n  Kind: %s\n  Extension: %s\n  Operation: %s\n", s.Name, s.Action, s.GAExtensionName.String(), s.GAOperationId.String())
+}
+
+func (s *RunGenevaActionStep) RequiredInputs() []StepDependency {
+	var deps []StepDependency
+	for _, val := range []Value{s.SecretKeyVault, s.SecretName, s.GAExtensionName, s.GAEndpoint, s.GAOperationId} {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
+	for _, val := range s.PayloadProperties {
+		if val.Input != nil {
+			deps = append(deps, val.Input.StepDependency)
+		}
+	}
+	slices.SortFunc(deps, SortDependencies)
+	deps = slices.Compact(deps)
+	return deps
+}
+
 const StepActionPublishGenevaAction = "PublishGenevaAction"
 
 type PublishGenevaActionStep struct {

--- a/pipelines/types/common_test.go
+++ b/pipelines/types/common_test.go
@@ -266,6 +266,30 @@ func TestRequiredInputs(t *testing.T) {
 			name:  "pav2 empty",
 			input: &Pav2Step{},
 		},
+		{
+			name: "runGenevaAction full",
+			input: &RunGenevaActionStep{
+				SecretKeyVault:  Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				SecretName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step2"}}},
+				GAExtensionName: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step3"}}},
+				GAEndpoint:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step4"}}},
+				GAOperationId:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+				PayloadProperties: map[string]Value{
+					"param1": {Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step5"}}},
+				},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+				{ResourceGroup: "rg", Step: "step2"},
+				{ResourceGroup: "rg", Step: "step3"},
+				{ResourceGroup: "rg", Step: "step4"},
+				{ResourceGroup: "rg", Step: "step5"},
+			},
+		},
+		{
+			name:  "runGenevaAction empty",
+			input: &RunGenevaActionStep{},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			if diff := cmp.Diff(testCase.expected, testCase.input.RequiredInputs()); diff != "" {
@@ -299,6 +323,7 @@ func TestIsWellFormedOverInputs(t *testing.T) {
 		{in: &SecretSyncStep{}, expected: true},
 		{in: &KustoStep{}, expected: true},
 		{in: &Pav2Step{}, expected: true},
+		{in: &RunGenevaActionStep{}, expected: true},
 		{in: &PublishGenevaActionStep{}, expected: true},
 		{in: &GenevaHealthStep{}, expected: true},
 		{in: &GenericStep{}, expected: false},

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -515,6 +515,54 @@
         }
       ]
     },
+    "runGenevaActionStep": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/stepMeta"
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "RunGenevaAction"
+            },
+            "secretKeyVault": {
+              "$ref": "#/definitions/value"
+            },
+            "secretName": {
+              "$ref": "#/definitions/value"
+            },
+            "gaExtensionName": {
+              "$ref": "#/definitions/value"
+            },
+            "gaEndpoint": {
+              "$ref": "#/definitions/value"
+            },
+            "gaOperationId": {
+              "$ref": "#/definitions/value"
+            },
+            "maxExecutionTime": {
+              "type": "string",
+              "description": "Max execution time duration (e.g., PT30M, PT1H).",
+              "default": "PT30M"
+            },
+            "payloadProperties": {
+              "type": "object",
+              "description": "Arbitrary key-value payload parameters for the Geneva Action operation.",
+              "additionalProperties": {
+                "$ref": "#/definitions/value"
+              }
+            }
+          },
+          "required": [
+            "secretKeyVault",
+            "secretName",
+            "gaExtensionName",
+            "gaOperationId"
+          ]
+        }
+      ]
+    },
     "genevaHealthStep": {
       "unevaluatedProperties": false,
       "allOf": [
@@ -1870,6 +1918,22 @@
                   },
                   "then": {
                     "$ref": "#/definitions/publishGenevaActionStep"
+                  }
+                },
+                {
+                  "if": {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "const": "RunGenevaAction"
+                      }
+                    },
+                    "required": [
+                      "action"
+                    ]
+                  },
+                  "then": {
+                    "$ref": "#/definitions/runGenevaActionStep"
                   }
                 },
                 {

--- a/pipelines/types/resourcegroup.go
+++ b/pipelines/types/resourcegroup.go
@@ -131,6 +131,8 @@ func (s *Steps) UnmarshalJSON(data []byte) error {
 			step = &Pav2Step{}
 		case StepActionPublishGenevaAction:
 			step = &PublishGenevaActionStep{}
+		case StepActionRunGenevaAction:
+			step = &RunGenevaActionStep{}
 		case StepActionGenevaHealth:
 			step = &GenevaHealthStep{}
 		case StepActionPublishGenevaAutomation:


### PR DESCRIPTION
Adds a new step type for invoking  Geneva Actions as part of deployment pipelines.

Required for https://redhat.atlassian.net/browse/AROSLSRE-886