### PR TITLE
Prevent panic on failed helm dry-run upgrade

### DIFF
--- a/tools/helm/options.go
+++ b/tools/helm/options.go
@@ -289,11 +289,14 @@ func (opts *Options) Deploy(ctx context.Context) error {
 			logger.Info("Doing dry-run of Helm release.")
 			releaser, releaseErr := runHelmUpgrade(ctx, logger, opts)
 			if releaseErr != nil {
-				logger.Error(releaseErr, "Failed to dry-run the Helm release.")
+				return fmt.Errorf("failed to dry-run the Helm release: %w", releaseErr)
 			}
 			release, err := releaserToV1Release(releaser)
 			if err != nil {
 				return fmt.Errorf("failed to convert release to v1: %w", err)
+			}
+			if release == nil {
+				return fmt.Errorf("dry-run of Helm release returned no release")
 			}
 
 			if err := removeOldFieldManager(ctx, logger, opts, release); err != nil {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-977

When Deploy runs the pre-rollout dry-run upgrade and it fails (e.g. Helm returns another 
operation (install/upgrade/rollback) is in progress), the error was only logged and execution
continued. releaserToV1Release then returned (nil, nil) and removeOldFieldManager
dereferenced the nil release, panicking at options.go:662.

This change returns the wrapped error immediately on dry-run failure and adds a nil guard on
the converted release, so Deploy exits cleanly with a descriptive error instead of panic.

 Observed failure:
  ```
ERROR: Failed to dry-run the Helm release. {"err":"another operation
  (install/upgrade/rollback) is in progress"}
  INFO: Removing old field manager from objects in release manifest.
  panic: runtime error: invalid memory address or nil pointer dereference
    github.com/Azure/ARO-Tools/tools/helm.removeOldFieldManager (options.go:662)
    github.com/Azure/ARO-Tools/tools/helm.(*Options).Deploy (options.go:299)
```