### PR TITLE
feat(pipelines): support shell step timeouts (AROSLSRE-997)

### DIFF
--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -35,6 +35,7 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: make deploy
+    timeout: 75m
     aksCluster: '{{ .aksName  }}'
     subnetName: '{{ .subnetName }}'
     shellIdentity:

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -406,6 +406,10 @@
         "command": {
           "type": "string"
         },
+        "timeout": {
+          "description": "Timeout is the maximum amount of time to wait for the shell step to complete. If unset, consumers should apply their default shell step timeout.",
+          "type": "string"
+        },
         "aksCluster": {
           "type": "string"
         },

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -408,7 +408,7 @@
         },
         "timeout": {
           "description": "Timeout is the maximum amount of time to wait for the shell step to complete. If unset, consumers should apply their default shell step timeout.",
-          "type": "string"
+          "$ref": "#/definitions/durationString"
         },
         "aksCluster": {
           "type": "string"

--- a/pipelines/types/shell.go
+++ b/pipelines/types/shell.go
@@ -40,6 +40,9 @@ type ShellStep struct {
 	ShellIdentity Value `json:"shellIdentity"`
 	// AdoArtifacts is a list of Azure DevOps artifacts to download before executing the shell step.
 	AdoArtifacts []AdoArtifactDownloadPipelineReference `json:"adoArtifacts,omitempty"`
+	// Timeout is the maximum amount of time to wait for the shell step to complete.
+	// If unset, consumers should apply their default shell step timeout.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // Reference represents a configurable reference

--- a/pipelines/types/shell.go
+++ b/pipelines/types/shell.go
@@ -40,7 +40,8 @@ type ShellStep struct {
 	ShellIdentity Value `json:"shellIdentity"`
 	// AdoArtifacts is a list of Azure DevOps artifacts to download before executing the shell step.
 	AdoArtifacts []AdoArtifactDownloadPipelineReference `json:"adoArtifacts,omitempty"`
-	// Timeout is the maximum amount of time to wait for the shell step to complete.
+	// Timeout is the maximum amount of time to wait for the shell step to complete, formatted as a duration string
+	// with a single h, m, or s unit.
 	// If unset, consumers should apply their default shell step timeout.
 	Timeout string `json:"timeout,omitempty"`
 }

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -36,6 +36,7 @@ resourceGroups:
     shellIdentity:
       configRef: aroDevopsMsiId
     subnetName: subnet
+    timeout: 75m
     variables:
     - configRef: maestro_image
       name: MAESTRO_IMAGE

--- a/pipelines/types/validation_test.go
+++ b/pipelines/types/validation_test.go
@@ -310,6 +310,51 @@ func TestValidatePipelineSchema(t *testing.T) {
 			},
 		},
 		{
+			name: "valid shell timeout",
+			pipeline: map[string]interface{}{
+				"serviceGroup": "test",
+				"rolloutName":  "test",
+				"resourceGroups": []interface{}{
+					map[string]interface{}{
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
+						"steps": []interface{}{
+							map[string]interface{}{
+								"name":    "step",
+								"action":  "Shell",
+								"command": "echo hello",
+								"timeout": "75m",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid shell timeout",
+			pipeline: map[string]interface{}{
+				"serviceGroup": "test",
+				"rolloutName":  "test",
+				"resourceGroups": []interface{}{
+					map[string]interface{}{
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
+						"steps": []interface{}{
+							map[string]interface{}{
+								"name":    "step",
+								"action":  "Shell",
+								"command": "echo hello",
+								"timeout": "tomorrow",
+							},
+						},
+					},
+				},
+			},
+			err: "pipeline is not compliant with schema pipeline.schema.v1",
+		},
+		{
 			name: "invalid",
 			pipeline: map[string]interface{}{
 				"serviceGroup": "test",


### PR DESCRIPTION
### What

Adds an optional `timeout` field to `Shell` pipeline steps in the ARO-Tools pipeline schema/types.

This lets downstream consumers configure long-running Ev2 Shell actions instead of relying on a hardcoded consumer default. Existing behavior remains unchanged when the field is omitted: consumers should continue applying their existing default timeout.

### Why

ARO-HCP needs to run a long-lived Shell mitigation step (`recreate-system-pool`) where the current default Shell timeout can be too short for safe multi-pool remediation plus wrapper/logging overhead.

### Validation

```text
go test ./pipelines/types
```

Also ran:

```text
go test ./pipelines/...
```

The broader package run reaches `pipelines/graph` and fails because Graphviz `dot` is not installed in this environment; `pipelines/types` passed.

Jira: [AROSLSRE-997](https://redhat.atlassian.net/browse/AROSLSRE-997)
