### PR TITLE
introduce stamped flag on topology services

### DIFF
--- a/pipelines/graph/graph.go
+++ b/pipelines/graph/graph.go
@@ -95,6 +95,7 @@ func ForPipeline(service *topology.Service, pipeline *types.Pipeline) (*Graph, e
 		PipelinePath: service.PipelinePath,
 		Children:     nil, // explicitly omitted to generate graph for one pipeline only
 		Metadata:     service.Metadata,
+		Stamped:      service.Stamped,
 	}
 
 	graph := &Graph{

--- a/pipelines/topology/types.go
+++ b/pipelines/topology/types.go
@@ -67,7 +67,11 @@ func Load(path string) (*Topology, error) {
 	}
 
 	var out Topology
-	return &out, yaml.Unmarshal(raw, &out)
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	out.PropagateStamped()
+	return &out, nil
 }
 
 func LoadCombined(paths []string) (*CombinedTopology, error) {

--- a/pipelines/topology/types.go
+++ b/pipelines/topology/types.go
@@ -46,6 +46,9 @@ type Service struct {
 	// Parent service located in a different topology file. Ignored if only one topology file is specified.
 	// Only allowed in input yaml on top-level services (i.e. those listed directly under Services in the topology file, not nested within another service's Children).
 	ExternalParent *string `json:"externalParent,omitempty"`
+
+	// Stamped marks this service group as stamp-scoped. Children inherit stamped from their parent.
+	Stamped bool `json:"stamped,omitempty"`
 }
 
 // Entrypoint describes an individual pipeline in the tree.
@@ -128,7 +131,25 @@ func LoadCombined(paths []string) (*CombinedTopology, error) {
 		externalParent.Children = append(externalParent.Children, *svc)
 	}
 
+	combinedTopology.PropagateStamped()
+
 	return &combinedTopology, nil
+}
+
+// PropagateStamped walks the service tree and sets Stamped = true on all children of stamped parents.
+func (t *Topology) PropagateStamped() {
+	for i := range t.Services {
+		propagateStamped(&t.Services[i], false)
+	}
+}
+
+func propagateStamped(s *Service, parentStamped bool) {
+	if parentStamped {
+		s.Stamped = true
+	}
+	for i := range s.Children {
+		propagateStamped(&s.Children[i], s.Stamped)
+	}
 }
 
 func (t *Topology) Validate() error {

--- a/pipelines/topology/types_test.go
+++ b/pipelines/topology/types_test.go
@@ -339,6 +339,113 @@ func TestDependency_Lookup(t *testing.T) {
 	}
 }
 
+func TestPropagateStamped(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		input    Topology
+		expected Topology
+	}{
+		{
+			name: "parent stamped, children inherit",
+			input: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "parent",
+						Stamped:      true,
+						Children: []Service{
+							{ServiceGroup: "child-a"},
+							{ServiceGroup: "child-b", Children: []Service{
+								{ServiceGroup: "grandchild"},
+							}},
+						},
+					},
+				},
+			},
+			expected: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "parent",
+						Stamped:      true,
+						Children: []Service{
+							{ServiceGroup: "child-a", Stamped: true},
+							{ServiceGroup: "child-b", Stamped: true, Children: []Service{
+								{ServiceGroup: "grandchild", Stamped: true},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "siblings unaffected",
+			input: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "stamped-parent",
+						Stamped:      true,
+						Children: []Service{
+							{ServiceGroup: "stamped-child"},
+						},
+					},
+					{
+						ServiceGroup: "non-stamped-sibling",
+						Children: []Service{
+							{ServiceGroup: "non-stamped-child"},
+						},
+					},
+				},
+			},
+			expected: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "stamped-parent",
+						Stamped:      true,
+						Children: []Service{
+							{ServiceGroup: "stamped-child", Stamped: true},
+						},
+					},
+					{
+						ServiceGroup: "non-stamped-sibling",
+						Children: []Service{
+							{ServiceGroup: "non-stamped-child"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no stamped services, no changes",
+			input: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "parent",
+						Children: []Service{
+							{ServiceGroup: "child"},
+						},
+					},
+				},
+			},
+			expected: Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "parent",
+						Children: []Service{
+							{ServiceGroup: "child"},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.input.PropagateStamped()
+			if diff := cmp.Diff(testCase.expected, testCase.input); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestLoadCombined_TopologyDirMapping(t *testing.T) {
 	teamAPath := filepath.Join("testdata", "team-a", "topology.yaml")
 	teamBPath := filepath.Join("testdata", "team-b", "topology.yaml")

--- a/pipelines/topology/types_test.go
+++ b/pipelines/topology/types_test.go
@@ -446,6 +446,41 @@ func TestPropagateStamped(t *testing.T) {
 	}
 }
 
+func TestLoad_PropagateStamped(t *testing.T) {
+	path := writeTempTopology(t, `services:
+- serviceGroup: parent
+  stamped: true
+  children:
+  - serviceGroup: child-a
+  - serviceGroup: child-b
+    children:
+    - serviceGroup: grandchild`)
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := &Topology{
+		Services: []Service{
+			{
+				ServiceGroup: "parent",
+				Stamped:      true,
+				Children: []Service{
+					{ServiceGroup: "child-a", Stamped: true},
+					{ServiceGroup: "child-b", Stamped: true, Children: []Service{
+						{ServiceGroup: "grandchild", Stamped: true},
+					}},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestLoadCombined_TopologyDirMapping(t *testing.T) {
 	teamAPath := filepath.Join("testdata", "team-a", "topology.yaml")
 	teamBPath := filepath.Join("testdata", "team-b", "topology.yaml")
@@ -474,29 +509,29 @@ func TestLoadCombined_TopologyDirMapping(t *testing.T) {
 	}
 }
 
+func writeTempTopology(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "topology-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(f.Name()); err != nil {
+			t.Errorf("failed to remove temp file: %v", err)
+		}
+	})
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("failed to write topology: %s", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close topology file: %s", err)
+	}
+	return f.Name()
+}
+
 func TestLoadCombined(t *testing.T) {
 	externalParentHCP := "Microsoft.Azure.ARO.HCP"
 	externalParentOther := "Microsoft.Azure.ARO.Other"
-
-	writeTempTopology := func(t *testing.T, content string) string {
-		t.Helper()
-		f, err := os.CreateTemp("", "topology-*.yaml")
-		if err != nil {
-			t.Fatalf("failed to create temp file: %s", err)
-		}
-		t.Cleanup(func() {
-			if err := os.Remove(f.Name()); err != nil {
-				t.Errorf("failed to remove temp file: %v", err)
-			}
-		})
-		if _, err := f.WriteString(content); err != nil {
-			t.Fatalf("failed to write topology: %s", err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatalf("failed to close topology file: %s", err)
-		}
-		return f.Name()
-	}
 
 	for _, testCase := range []struct {
 		name       string
@@ -659,6 +694,71 @@ func TestLoadCombined(t *testing.T) {
     purpose: child
     externalParent: Microsoft.Azure.ARO.HCP`},
 			err: true,
+		},
+		{
+			name: "stamped propagates across external parent graft",
+			topologies: []string{
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP
+  pipelinePath: foo
+  purpose: root
+  stamped: true`,
+				`services:
+- serviceGroup: Microsoft.Azure.ARO.HCP.Child
+  pipelinePath: bar
+  purpose: grafted child
+  externalParent: Microsoft.Azure.ARO.HCP
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Child.Grand
+    pipelinePath: baz
+    purpose: grandchild
+- serviceGroup: Microsoft.Azure.ARO.Classic
+  pipelinePath: classic
+  purpose: independent service
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.Classic.Sub
+    pipelinePath: sub
+    purpose: independent child`,
+			},
+			expected: &Topology{
+				Services: []Service{
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.HCP",
+						PipelinePath: "foo",
+						Purpose:      "root",
+						Stamped:      true,
+						Children: []Service{
+							{
+								ServiceGroup:   "Microsoft.Azure.ARO.HCP.Child",
+								PipelinePath:   "bar",
+								Purpose:        "grafted child",
+								Stamped:        true,
+								ExternalParent: func() *string { s := "Microsoft.Azure.ARO.HCP"; return &s }(),
+								Children: []Service{
+									{
+										ServiceGroup: "Microsoft.Azure.ARO.HCP.Child.Grand",
+										PipelinePath: "baz",
+										Purpose:      "grandchild",
+										Stamped:      true,
+									},
+								},
+							},
+						},
+					},
+					{
+						ServiceGroup: "Microsoft.Azure.ARO.Classic",
+						PipelinePath: "classic",
+						Purpose:      "independent service",
+						Children: []Service{
+							{
+								ServiceGroup: "Microsoft.Azure.ARO.Classic.Sub",
+								PipelinePath: "sub",
+								Purpose:      "independent child",
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "errors when external parent does not exist",


### PR DESCRIPTION
EV2 supports deploying multiple instances (stamps) of a service group within a single region. To leverage this, the generator needs to know which service groups are stamp-scoped so it can populate the Stamps field on their ServiceResourceGroupDefinitions.

Add a Stamped bool to topology.Service and propagate it from parent to children during LoadCombined, after external parents are resolved. This ensures every consumer of the topology gets correct stamp inheritance without needing to call propagation explicitly.

https://redhat.atlassian.net/browse/ARO-26932