### PR TITLE
fix(grafanactl): require a regex on the dashboard datasource variable

### DIFF
--- a/tools/grafanactl/internal/grafana/syncer.go
+++ b/tools/grafanactl/internal/grafana/syncer.go
@@ -353,9 +353,10 @@ func validateDashboard(localDashboard sdk.Board, folderPath string) (errors []Va
 		})
 	}
 
-	// Warning: check for regex on datasource variable
+	// Require a regex on the datasource variable so dashboards cannot list
+	// every datasource in their picker.
 	if datasourceVar != nil && datasourceVar.Regex == "" {
-		warnings = append(warnings, ValidationIssue{
+		errors = append(errors, ValidationIssue{
 			Folder:  folderPath,
 			Title:   localDashboard.Title,
 			Message: "Dashboard does not have a regex set for the datasource variable",


### PR DESCRIPTION
### What

Promote the dashboard datasource-variable regex check from a warning to a hard validation error in `grafanactl`.

### Why

`validateDashboard` previously only warned when a datasource template variable had no regex. A dashboard with an unconstrained datasource picker — which lists every datasource in the org, including obsolete Managed Prometheus datasources that carry no data — would still pass `grafanactl verify dashboards` in CI.

Making it an error lets teams enforce that every dashboard constrains its datasource variable. Dashboards that intentionally allow any datasource can set a permissive regex (e.g. `^Managed_Prometheus_.*$`).

This complements Azure/ARO-HCP#5653, which gives every ARO-HCP dashboard a datasource regex; with that merged, no ARO-HCP dashboard is left unfiltered, so this check can be enforced without breaking CI.

### Changes

- `internal/grafana/syncer.go`: missing-regex issue moved from `warnings` to `errors` (one-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)