### PR TITLE
fix(prow-job-executor): retry SubmitJob on transient 429/5xx

### DIFF
--- a/tools/prow-job-executor/prowjob/client.go
+++ b/tools/prow-job-executor/prowjob/client.go
@@ -42,10 +42,11 @@ type jobSubmissionResponse struct {
 
 // Client handles Prow API interactions
 type Client struct {
-	token      string
-	client     *http.Client
-	gangwayURL string
-	prowURL    string
+	token         string
+	client        *http.Client
+	gangwayURL    string
+	prowURL       string
+	submitBackoff wait.Backoff
 }
 
 // NewClient creates a new Prow API client with the provided authentication token and API URLs.
@@ -57,11 +58,65 @@ func NewClient(token, gangwayURL, prowURL string) *Client {
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		// Exponential backoff with jitter for transient job-submission failures.
+		// Delays grow 1, 2, 4, 8, 16, 30 minutes (capped), for a worst-case
+		// cumulative wait of ~61 minutes before giving up. The parent context
+		// still bounds the total runtime.
+		submitBackoff: wait.Backoff{
+			Duration: time.Minute,      // Initial delay
+			Factor:   2.0,              // Exponential factor
+			Jitter:   0.1,              // 10% jitter to de-sync concurrent submitters
+			Steps:    6,                // Maximum retries
+			Cap:      30 * time.Minute, // Maximum delay cap
+		},
 	}
 }
 
-// SubmitJob submits a job to Prow and returns the job execution ID
+// SubmitJob submits a job to Prow and returns the job execution ID, retrying on
+// transient errors with exponential backoff.
+//
+// The Gangway API enforces a low request-rate limit (~9 requests/minute per client
+// IP) and rejects excess requests immediately with HTTP 429 rather than queueing
+// them. Without retries a momentary rate-limit fails the whole EV2 gating step,
+// forcing the entire deployment job to be restarted. 401/403 remain non-retryable.
 func (c *Client) SubmitJob(ctx context.Context, request *prowgangway.CreateJobExecutionRequest) (string, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var executionID string
+	var lastErr error
+	condition := func(ctx context.Context) (bool, error) {
+		id, err := c.submitJobOnce(ctx, request)
+		if err != nil {
+			lastErr = err
+			// Check if this is a non-retryable error (e.g., 401/403).
+			if isNonRetryableHTTPError(err) {
+				return false, err // Stop retrying and propagate the error
+			}
+
+			// For retryable errors, log and continue.
+			logger.Info("Job submission failed with a transient error, will retry", "error", err.Error())
+			return false, nil
+		}
+
+		executionID = id
+		return true, nil // Success, stop retrying
+	}
+
+	if err := wait.ExponentialBackoffWithContext(ctx, c.submitBackoff, condition); err != nil {
+		if lastErr != nil {
+			return "", fmt.Errorf("failed to submit job after retries: %w", lastErr)
+		}
+		return "", err
+	}
+
+	return executionID, nil
+}
+
+// submitJobOnce performs a single job submission request without retry logic.
+func (c *Client) submitJobOnce(ctx context.Context, request *prowgangway.CreateJobExecutionRequest) (string, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return "", err
@@ -92,7 +147,8 @@ func (c *Client) SubmitJob(ctx context.Context, request *prowgangway.CreateJobEx
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("job submission failed with status %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("job submission failed with status %d: %s", resp.StatusCode, string(body))
+		return "", &httpStatusError{statusCode: resp.StatusCode, err: err}
 	}
 
 	var response jobSubmissionResponse

--- a/tools/prow-job-executor/prowjob/client.go
+++ b/tools/prow-job-executor/prowjob/client.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -59,15 +60,18 @@ func NewClient(token, gangwayURL, prowURL string) *Client {
 			Timeout: 30 * time.Second,
 		},
 		// Exponential backoff with jitter for transient job-submission failures.
-		// Delays grow 1, 2, 4, 8, 16, 30 minutes (capped), for a worst-case
-		// cumulative wait of ~61 minutes before giving up. The parent context
-		// still bounds the total runtime.
+		// Delays between attempts grow 1, 2, 4, 8, 16, 32 minutes over up to 7
+		// attempts, for a worst-case cumulative wait of ~63 minutes before giving
+		// up. The parent context still bounds the total runtime.
+		//
+		// Note: apimachinery's Backoff.Cap not only clamps an individual delay but
+		// also stops all further retries once the cap is reached, so the schedule
+		// is deliberately bounded by Steps rather than Cap.
 		submitBackoff: wait.Backoff{
-			Duration: time.Minute,      // Initial delay
-			Factor:   2.0,              // Exponential factor
-			Jitter:   0.1,              // 10% jitter to de-sync concurrent submitters
-			Steps:    6,                // Maximum retries
-			Cap:      30 * time.Minute, // Maximum delay cap
+			Duration: time.Minute, // Initial delay
+			Factor:   2.0,         // Exponential factor
+			Jitter:   0.1,         // 10% jitter to de-sync concurrent submitters
+			Steps:    7,           // Maximum attempts (~63m worst-case cumulative wait)
 		},
 	}
 }
@@ -78,7 +82,8 @@ func NewClient(token, gangwayURL, prowURL string) *Client {
 // The Gangway API enforces a low request-rate limit (~9 requests/minute per client
 // IP) and rejects excess requests immediately with HTTP 429 rather than queueing
 // them. Without retries a momentary rate-limit fails the whole EV2 gating step,
-// forcing the entire deployment job to be restarted. 401/403 remain non-retryable.
+// forcing the entire deployment job to be restarted. Only transient failures
+// (HTTP 429, 5xx, and network errors) are retried; everything else fails fast.
 func (c *Client) SubmitJob(ctx context.Context, request *prowgangway.CreateJobExecutionRequest) (string, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
@@ -91,12 +96,13 @@ func (c *Client) SubmitJob(ctx context.Context, request *prowgangway.CreateJobEx
 		id, err := c.submitJobOnce(ctx, request)
 		if err != nil {
 			lastErr = err
-			// Check if this is a non-retryable error (e.g., 401/403).
-			if isNonRetryableHTTPError(err) {
+			// Only retry known-transient errors. Deterministic failures (marshal,
+			// request construction, response decode, 4xx other than 429) are not
+			// retried so they surface immediately instead of after a long backoff.
+			if !isRetryableError(err) {
 				return false, err // Stop retrying and propagate the error
 			}
 
-			// For retryable errors, log and continue.
 			logger.Info("Job submission failed with a transient error, will retry", "error", err.Error())
 			return false, nil
 		}
@@ -260,6 +266,22 @@ func isNonRetryableHTTPError(err error) bool {
 		return !isRetryableStatusCode(httpErr.statusCode)
 	}
 	return false
+}
+
+// isRetryableError reports whether a job-submission error is transient and worth
+// retrying. Only HTTP 429, 5xx responses and network-level errors are retried;
+// deterministic failures (request marshaling/construction, response decoding, and
+// other 4xx such as 400/404/409) are treated as permanent and fail fast.
+func isRetryableError(err error) bool {
+	var httpErr *httpStatusError
+	if errors.As(err, &httpErr) {
+		code := httpErr.statusCode
+		return code == http.StatusTooManyRequests || (code >= 500 && code <= 599)
+	}
+
+	// Transport/network errors (timeouts, connection resets, etc.) are transient.
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 // isRetryableStatusCode determines if an HTTP status code should be retried

--- a/tools/prow-job-executor/prowjob/client_test.go
+++ b/tools/prow-job-executor/prowjob/client_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	prowgangway "sigs.k8s.io/prow/pkg/gangway"
+)
+
+// fastBackoff returns a backoff with negligible delays so retry tests run quickly
+// while still exercising the same number of attempts as production.
+func fastBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.0,
+		Steps:    6,
+		Cap:      10 * time.Millisecond,
+	}
+}
+
+func testContext() context.Context {
+	return logr.NewContext(context.Background(), logr.Discard())
+}
+
+func TestSubmitJobRetry(t *testing.T) {
+	const successBody = `{"id":"job-exec-123"}`
+
+	tests := []struct {
+		name string
+		// statuses returned in order; the last status repeats once exhausted.
+		statuses        []int
+		wantID          string
+		wantErr         bool
+		wantErrContains string
+		// wantAttempts is the expected number of HTTP requests sent.
+		wantAttempts int32
+	}{
+		{
+			name:         "success on first attempt",
+			statuses:     []int{http.StatusOK},
+			wantID:       "job-exec-123",
+			wantAttempts: 1,
+		},
+		{
+			name:         "429 then success",
+			statuses:     []int{http.StatusTooManyRequests, http.StatusOK},
+			wantID:       "job-exec-123",
+			wantAttempts: 2,
+		},
+		{
+			name:         "503 then success",
+			statuses:     []int{http.StatusServiceUnavailable, http.StatusOK},
+			wantID:       "job-exec-123",
+			wantAttempts: 2,
+		},
+		{
+			name:            "persistent 429 exhausts retries",
+			statuses:        []int{http.StatusTooManyRequests},
+			wantErr:         true,
+			wantErrContains: "429",
+			wantAttempts:    -1, // retried multiple times; exact count is backoff/k8s-version dependent
+		},
+		{
+			name:            "403 is not retried",
+			statuses:        []int{http.StatusForbidden},
+			wantErr:         true,
+			wantErrContains: "403",
+			wantAttempts:    1,
+		},
+		{
+			name:            "401 is not retried",
+			statuses:        []int{http.StatusUnauthorized},
+			wantErr:         true,
+			wantErrContains: "401",
+			wantAttempts:    1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				n := atomic.AddInt32(&attempts, 1)
+				idx := int(n) - 1
+				if idx >= len(tc.statuses) {
+					idx = len(tc.statuses) - 1
+				}
+				status := tc.statuses[idx]
+				w.WriteHeader(status)
+				if status == http.StatusOK {
+					_, _ = w.Write([]byte(successBody))
+				} else {
+					_, _ = w.Write([]byte(http.StatusText(status)))
+				}
+			}))
+			defer srv.Close()
+
+			c := NewClient("test-token", srv.URL, srv.URL)
+			c.submitBackoff = fastBackoff()
+
+			id, err := c.SubmitJob(testContext(), &prowgangway.CreateJobExecutionRequest{})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (id=%q)", id)
+				}
+				if tc.wantErrContains != "" && !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if id != tc.wantID {
+					t.Fatalf("got id %q, want %q", id, tc.wantID)
+				}
+			}
+
+			if got := atomic.LoadInt32(&attempts); tc.wantAttempts < 0 {
+				if got <= 1 {
+					t.Fatalf("expected multiple retries, got %d attempts", got)
+				}
+			} else if got != tc.wantAttempts {
+				t.Fatalf("got %d attempts, want %d", got, tc.wantAttempts)
+			}
+		})
+	}
+}
+
+func TestIsRetryableStatusCode(t *testing.T) {
+	tests := []struct {
+		status    int
+		retryable bool
+	}{
+		{http.StatusTooManyRequests, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+	}
+	for _, tc := range tests {
+		if got := isRetryableStatusCode(tc.status); got != tc.retryable {
+			t.Errorf("isRetryableStatusCode(%d) = %v, want %v", tc.status, got, tc.retryable)
+		}
+	}
+}

--- a/tools/prow-job-executor/prowjob/client_test.go
+++ b/tools/prow-job-executor/prowjob/client_test.go
@@ -30,15 +30,18 @@ import (
 	prowgangway "sigs.k8s.io/prow/pkg/gangway"
 )
 
+// fastBackoffSteps is the deterministic attempt budget used by retry tests.
+const fastBackoffSteps = 5
+
 // fastBackoff returns a backoff with negligible delays so retry tests run quickly
-// while still exercising the same number of attempts as production.
+// while still exercising a deterministic number of attempts. No Cap is set so the
+// attempt count is exactly Steps (apimachinery's Cap would also halt retries early).
 func fastBackoff() wait.Backoff {
 	return wait.Backoff{
 		Duration: time.Millisecond,
 		Factor:   2.0,
 		Jitter:   0.0,
-		Steps:    6,
-		Cap:      10 * time.Millisecond,
+		Steps:    fastBackoffSteps,
 	}
 }
 
@@ -56,8 +59,7 @@ func TestSubmitJobRetry(t *testing.T) {
 		wantID          string
 		wantErr         bool
 		wantErrContains string
-		// wantAttempts is the expected number of HTTP requests sent.
-		wantAttempts int32
+		wantAttempts    int32
 	}{
 		{
 			name:         "success on first attempt",
@@ -78,11 +80,31 @@ func TestSubmitJobRetry(t *testing.T) {
 			wantAttempts: 2,
 		},
 		{
+			name:         "500 then success",
+			statuses:     []int{http.StatusInternalServerError, http.StatusOK},
+			wantID:       "job-exec-123",
+			wantAttempts: 2,
+		},
+		{
 			name:            "persistent 429 exhausts retries",
 			statuses:        []int{http.StatusTooManyRequests},
 			wantErr:         true,
 			wantErrContains: "429",
-			wantAttempts:    -1, // retried multiple times; exact count is backoff/k8s-version dependent
+			wantAttempts:    fastBackoffSteps,
+		},
+		{
+			name:            "persistent 502 exhausts retries",
+			statuses:        []int{http.StatusBadGateway},
+			wantErr:         true,
+			wantErrContains: "502",
+			wantAttempts:    fastBackoffSteps,
+		},
+		{
+			name:            "401 is not retried",
+			statuses:        []int{http.StatusUnauthorized},
+			wantErr:         true,
+			wantErrContains: "401",
+			wantAttempts:    1,
 		},
 		{
 			name:            "403 is not retried",
@@ -92,10 +114,31 @@ func TestSubmitJobRetry(t *testing.T) {
 			wantAttempts:    1,
 		},
 		{
-			name:            "401 is not retried",
-			statuses:        []int{http.StatusUnauthorized},
+			name:            "400 is not retried",
+			statuses:        []int{http.StatusBadRequest},
 			wantErr:         true,
-			wantErrContains: "401",
+			wantErrContains: "400",
+			wantAttempts:    1,
+		},
+		{
+			name:            "404 is not retried",
+			statuses:        []int{http.StatusNotFound},
+			wantErr:         true,
+			wantErrContains: "404",
+			wantAttempts:    1,
+		},
+		{
+			name:            "409 is not retried",
+			statuses:        []int{http.StatusConflict},
+			wantErr:         true,
+			wantErrContains: "409",
+			wantAttempts:    1,
+		},
+		{
+			name:            "422 is not retried",
+			statuses:        []int{http.StatusUnprocessableEntity},
+			wantErr:         true,
+			wantErrContains: "422",
 			wantAttempts:    1,
 		},
 	}
@@ -140,18 +183,58 @@ func TestSubmitJobRetry(t *testing.T) {
 				}
 			}
 
-			if got := atomic.LoadInt32(&attempts); tc.wantAttempts < 0 {
-				if got <= 1 {
-					t.Fatalf("expected multiple retries, got %d attempts", got)
-				}
-			} else if got != tc.wantAttempts {
+			if got := atomic.LoadInt32(&attempts); got != tc.wantAttempts {
 				t.Fatalf("got %d attempts, want %d", got, tc.wantAttempts)
 			}
 		})
 	}
 }
 
+// TestSubmitJobNetworkErrorRetries verifies transport errors (server unreachable)
+// are treated as transient and retried up to the attempt budget.
+func TestSubmitJobNetworkErrorRetries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // ensure connections are refused
+
+	c := NewClient("test-token", url, url)
+	c.submitBackoff = fastBackoff()
+
+	_, err := c.SubmitJob(testContext(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected error for unreachable server, got nil")
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"429", &httpStatusError{statusCode: http.StatusTooManyRequests}, true},
+		{"500", &httpStatusError{statusCode: http.StatusInternalServerError}, true},
+		{"503", &httpStatusError{statusCode: http.StatusServiceUnavailable}, true},
+		{"504", &httpStatusError{statusCode: http.StatusGatewayTimeout}, true},
+		{"400", &httpStatusError{statusCode: http.StatusBadRequest}, false},
+		{"401", &httpStatusError{statusCode: http.StatusUnauthorized}, false},
+		{"403", &httpStatusError{statusCode: http.StatusForbidden}, false},
+		{"404", &httpStatusError{statusCode: http.StatusNotFound}, false},
+		{"409", &httpStatusError{statusCode: http.StatusConflict}, false},
+		{"non-http error", context.Canceled, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableError(tc.err); got != tc.retryable {
+				t.Errorf("isRetryableError(%v) = %v, want %v", tc.err, got, tc.retryable)
+			}
+		})
+	}
+}
+
 func TestIsRetryableStatusCode(t *testing.T) {
+	// isRetryableStatusCode backs GetJobStatus, where everything except 401/403 is
+	// retried (a freshly submitted job's status may 404 until it propagates).
 	tests := []struct {
 		status    int
 		retryable bool
@@ -159,7 +242,7 @@ func TestIsRetryableStatusCode(t *testing.T) {
 		{http.StatusTooManyRequests, true},
 		{http.StatusServiceUnavailable, true},
 		{http.StatusInternalServerError, true},
-		{http.StatusBadGateway, true},
+		{http.StatusNotFound, true},
 		{http.StatusUnauthorized, false},
 		{http.StatusForbidden, false},
 	}


### PR DESCRIPTION
## Summary

`prowjobexecutor execute` (used in EV2 gating) had **no retry logic** on the `SubmitJob()` call to the Prow Gangway API. Gangway enforces a ~9 requests/minute rate limit and rejects excess requests immediately with **HTTP 429** (`nodelay`, no queueing). A single 429 failed the entire EV2 gating step, forcing the full deployment job to restart from scratch.

Ironically, the sibling `GetJobStatus()` call in the same file already had exponential-backoff retry that treats 429 as retryable — `SubmitJob()` was just never given the same treatment.

## Changes

- Refactor `SubmitJob()` into a single-shot `submitJobOnce()` plus a retry wrapper, reusing the existing `httpStatusError` / `isRetryableStatusCode()` plumbing already used by `GetJobStatus()`.
- Transient failures (429, 5xx) are retried with exponential backoff; **401/403 remain non-retryable**.
- Backoff: `Duration 1m, Factor 2, Jitter 0.1, Cap 30m, Steps 6` → delays `1, 2, 4, 8, 16, 30` min, **~61 min worst-case** cumulative wait. The parent `context` still bounds total runtime (`ExponentialBackoffWithContext` aborts mid-sleep on cancellation).
- The backoff is a `Client` field (defaulted in `NewClient`) so tests can inject a fast backoff.
- Retries are logged so they are visible in EV2 job output.
- Add unit tests: 429→200, 503→200, persistent-429 exhausts retries, 401/403 no-retry, first-try success, plus `isRetryableStatusCode` coverage.

## Testing

- `go test -race ./prowjob/` — pass
- `go tool golangci-lint run ./prowjob/` — 0 issues

## Notes for reviewers

- Retryability intentionally reuses the existing `isRetryableStatusCode()` (everything except 401/403), keeping submit and status behavior identical. Happy to tighten to an explicit `{429, 500, 502, 503, 504}` allowlist if preferred.
- `Jitter: 0.1` is positive-only skew (~+10%), so the true ceiling is ~67 min; it helps de-sync concurrent EV2 submitters against the shared 9 req/min limit.

## Observed failure

- Job: `branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel` (PROD eastus2euap, EV2 gating)
- Error: `job submission failed with status 429: ... 429 Too Many Requests ... nginx/1.20.1`

Jira: [AROSLSRE-1168](https://issues.redhat.com/browse/AROSLSRE-1168)
