### PR TITLE
fix(helm): retry deploy on transient IMDS/MSI credential errors (AROSLSRE-1234)

### DIFF
--- a/tools/helm/options.go
+++ b/tools/helm/options.go
@@ -373,7 +373,9 @@ func applyNamespace(ctx context.Context, logger logr.Logger, client corev1client
 // transient credential/connection error. Worst case ~31s of waiting across 5 attempts (1, 2, 4, 8,
 // 16s, capped at 30s), which comfortably absorbs a brief IMDS blip without meaningfully delaying a
 // genuinely-broken rollout.
-func transientCredentialErrorBackoff() wait.Backoff {
+//
+// It is a var so tests can substitute a fast, no-sleep backoff.
+var transientCredentialErrorBackoff = func() wait.Backoff {
 	return wait.Backoff{
 		Duration: time.Second,
 		Factor:   2.0,
@@ -400,6 +402,12 @@ func transientCredentialErrorBackoff() wait.Backoff {
 // transient (timeouts, throttling, server-side unavailability).
 func isTransientCredentialError(err error) bool {
 	if err == nil {
+		return false
+	}
+	// Caller-driven cancellation or timeout is not a transient API failure: retrying would spin
+	// uselessly and hide the real reason the operation stopped. Fail fast so the context error
+	// propagates to the caller.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	var apiStatus kapierrors.APIStatus
@@ -432,6 +440,11 @@ func retryOnTransientCredentialError(ctx context.Context, logger logr.Logger, de
 		return false, nil
 	}
 	if err := wait.ExponentialBackoffWithContext(ctx, transientCredentialErrorBackoff(), condition); err != nil {
+		// Preserve caller cancellation/deadline so the real reason surfaces, rather than masking
+		// it as "giving up after transient errors" (wait.Interrupted also matches context errors).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if wait.Interrupted(err) && lastErr != nil {
 			return fmt.Errorf("%s: giving up after transient errors: %w", description, lastErr)
 		}

--- a/tools/helm/options.go
+++ b/tools/helm/options.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
@@ -272,8 +273,14 @@ func (opts *Options) Deploy(ctx context.Context) error {
 
 	logger.Info("Applying namespaces.")
 	// Helm does not let us manage namespaces easily, so we need to apply them ourselves, up-front.
+	// This is also the first call that reaches the API server, so it is where a transient failure to
+	// obtain credentials (e.g. a momentary inability to reach IMDS when the exec credential plugin
+	// mints the AKS token) first surfaces - retry those rather than failing the whole rollout step.
 	for _, namespace := range opts.Namespaces {
-		if err := applyNamespace(ctx, logger, opts.NamespacesClient, namespace, opts.DryRun); err != nil {
+		namespace := namespace
+		if err := retryOnTransientCredentialError(ctx, logger, fmt.Sprintf("apply namespace %s", namespace.Name), func(ctx context.Context) error {
+			return applyNamespace(ctx, logger, opts.NamespacesClient, namespace, opts.DryRun)
+		}); err != nil {
 			return err
 		}
 	}
@@ -359,6 +366,77 @@ func applyNamespace(ctx context.Context, logger logr.Logger, client corev1client
 		return fmt.Errorf("failed to apply namespace %s: %w", namespace.Name, err)
 	}
 	logger.WithValues("namespace", namespace.Name).Info("Namespace applied successfully.")
+	return nil
+}
+
+// transientCredentialErrorBackoff controls how often we retry an API-server call that failed with a
+// transient credential/connection error. Worst case ~31s of waiting across 5 attempts (1, 2, 4, 8,
+// 16s, capped at 30s), which comfortably absorbs a brief IMDS blip without meaningfully delaying a
+// genuinely-broken rollout.
+func transientCredentialErrorBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    5,
+		Cap:      30 * time.Second,
+	}
+}
+
+// isTransientCredentialError reports whether err looks like a transient failure to obtain
+// credentials or otherwise reach the API server, as opposed to a deterministic Kubernetes API
+// response (RBAC denial, invalid request, conflict, ...).
+//
+// The exec credential plugin (kubelogin, in azurecli mode) shells back to the managed identity /
+// IMDS to mint the AKS token. When IMDS is momentarily unreachable the plugin exits non-zero and
+// client-go returns a transport-level error with no Kubernetes API status attached, e.g.:
+//
+//	Patch "https://...azmk8s.io/api/v1/namespaces/acrpull": getting credentials:
+//	exec: executable kubelogin failed with exit code 1
+//
+// Genuine auth/config problems (401 Unauthorized, 403 Forbidden, ...) come back as API status
+// errors and must fail fast, so we only treat as retryable either errors that carry no API status
+// at all (transport/credential failures) or the small set of API statuses that are themselves
+// transient (timeouts, throttling, server-side unavailability).
+func isTransientCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiStatus kapierrors.APIStatus
+	if !errors.As(err, &apiStatus) {
+		// No Kubernetes API status: this is a transport-level / credential-plugin failure.
+		return true
+	}
+	return kapierrors.IsServerTimeout(err) ||
+		kapierrors.IsTimeout(err) ||
+		kapierrors.IsTooManyRequests(err) ||
+		kapierrors.IsInternalError(err) ||
+		kapierrors.IsServiceUnavailable(err)
+}
+
+// retryOnTransientCredentialError runs fn, retrying with exponential backoff while it fails with a
+// transient credential/connection error (see isTransientCredentialError). Deterministic failures are
+// returned immediately so genuine auth/config problems still fail fast.
+func retryOnTransientCredentialError(ctx context.Context, logger logr.Logger, description string, fn func(context.Context) error) error {
+	var lastErr error
+	condition := func(ctx context.Context) (bool, error) {
+		err := fn(ctx)
+		if err == nil {
+			return true, nil
+		}
+		if !isTransientCredentialError(err) {
+			return false, err
+		}
+		lastErr = err
+		logger.WithValues("operation", description, "error", err.Error()).Info("Transient error reaching the API server; retrying.")
+		return false, nil
+	}
+	if err := wait.ExponentialBackoffWithContext(ctx, transientCredentialErrorBackoff(), condition); err != nil {
+		if wait.Interrupted(err) && lastErr != nil {
+			return fmt.Errorf("%s: giving up after transient errors: %w", description, lastErr)
+		}
+		return err
+	}
 	return nil
 }
 

--- a/tools/helm/retry_test.go
+++ b/tools/helm/retry_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestIsTransientCredentialError(t *testing.T) {
@@ -57,6 +59,21 @@ func TestIsTransientCredentialError(t *testing.T) {
 			err:  fmt.Errorf("apply failed: %w", kapierrors.NewUnauthorized("token invalid")),
 			want: false,
 		},
+		{
+			name: "context canceled is not transient",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "context deadline exceeded is not transient",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "wrapped context canceled is not transient",
+			err:  fmt.Errorf("apply namespace: %w", context.Canceled),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,6 +86,13 @@ func TestIsTransientCredentialError(t *testing.T) {
 
 func TestRetryOnTransientCredentialError(t *testing.T) {
 	logger := testr.New(t)
+
+	// Use a fast, no-sleep backoff so retries do not consume real wall-clock time.
+	restore := transientCredentialErrorBackoff
+	transientCredentialErrorBackoff = func() wait.Backoff {
+		return wait.Backoff{Duration: time.Microsecond, Factor: 1.0, Steps: 5}
+	}
+	t.Cleanup(func() { transientCredentialErrorBackoff = restore })
 
 	t.Run("retries transient failures then succeeds", func(t *testing.T) {
 		calls := 0
@@ -99,6 +123,19 @@ func TestRetryOnTransientCredentialError(t *testing.T) {
 		}
 		if calls != 1 {
 			t.Fatalf("expected exactly 1 attempt, got %d", calls)
+		}
+	})
+
+	t.Run("preserves context cancellation instead of masking it", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := retryOnTransientCredentialError(ctx, logger, "apply namespace acrpull", func(context.Context) error {
+			calls++
+			return errors.New("getting credentials: exec: executable kubelogin failed with exit code 1")
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
 		}
 	})
 }

--- a/tools/helm/retry_test.go
+++ b/tools/helm/retry_test.go
@@ -1,0 +1,104 @@
+package helm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestIsTransientCredentialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not transient",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "credential plugin failure has no API status, is transient",
+			err:  fmt.Errorf(`failed to apply namespace acrpull: Patch "https://x.azmk8s.io/api/v1/namespaces/acrpull": getting credentials: exec: executable kubelogin failed with exit code 1`),
+			want: true,
+		},
+		{
+			name: "plain transport error is transient",
+			err:  errors.New("connection aborted"),
+			want: true,
+		},
+		{
+			name: "unauthorized is a genuine auth failure, not transient",
+			err:  kapierrors.NewUnauthorized("token invalid"),
+			want: false,
+		},
+		{
+			name: "service unavailable is transient",
+			err:  kapierrors.NewServiceUnavailable("apiserver overloaded"),
+			want: true,
+		},
+		{
+			name: "too many requests is transient",
+			err:  kapierrors.NewTooManyRequests("slow down", 1),
+			want: true,
+		},
+		{
+			name: "internal error is transient",
+			err:  kapierrors.NewInternalError(errors.New("boom")),
+			want: true,
+		},
+		{
+			name: "wrapped unauthorized is still not transient",
+			err:  fmt.Errorf("apply failed: %w", kapierrors.NewUnauthorized("token invalid")),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientCredentialError(tt.err); got != tt.want {
+				t.Fatalf("isTransientCredentialError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryOnTransientCredentialError(t *testing.T) {
+	logger := testr.New(t)
+
+	t.Run("retries transient failures then succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryOnTransientCredentialError(context.Background(), logger, "apply namespace acrpull", func(context.Context) error {
+			calls++
+			if calls < 3 {
+				return errors.New("getting credentials: exec: executable kubelogin failed with exit code 1")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 attempts, got %d", calls)
+		}
+	})
+
+	t.Run("fails fast on deterministic error", func(t *testing.T) {
+		calls := 0
+		want := kapierrors.NewUnauthorized("token invalid")
+		err := retryOnTransientCredentialError(context.Background(), logger, "apply namespace acrpull", func(context.Context) error {
+			calls++
+			return want
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("expected unauthorized error, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected exactly 1 attempt, got %d", calls)
+		}
+	})
+}


### PR DESCRIPTION
<!-- Jira: AROSLSRE-1234 -->

### Problem

The per-cluster Helm deploy step (`helmdeploy deploy-helm`) authenticates to the AKS API server via `kubelogin` in `azurecli` mode, which shells back to the managed identity / IMDS to mint a token. When IMDS is momentarily unreachable, the exec credential plugin exits non-zero and the **first** API-server call — the up-front namespace apply — fails the whole rollout step.

Observed on the `acrpull` prod rollout `build.168714989` (`ARO-HCP 15d705123be4`) on `prod-centralindia-mgmt-1`:

```text
AzureCLICredential: ERROR: Failed to connect to MSI. Please make sure MSI is configured correctly and check the network connection.
Error detail: ('Connection aborted.', BadStatusLine('HTTP/1.1 000 status code 0'))
-> failed to apply namespace acrpull: Patch ".../namespaces/acrpull": getting credentials:
   exec: executable kubelogin failed with exit code 1
```

`az login --identity` and three `az aks` calls succeeded ~16s earlier with the same MSI, so this is a transient flake, not a misconfiguration. The standalone `az` calls in the rollout script are wrapped in `az_retry`, but the in-process token acquisition inside `deploy-helm` had no retry.

### What

Wrap the namespace apply in an exponential backoff (`wait.ExponentialBackoffWithContext`, 5 steps: 1/2/4/8/16s, cap 30s) that retries transient credential/connection errors:

```text
helmdeploy deploy-helm
  -> apply namespace -> kubelogin token via IMDS -> Connection aborted
       -> retry (backoff) -> token minted -> apply succeeds
```

`isTransientCredentialError` scopes the retry precisely:
- errors with **no** Kubernetes API status (transport / credential-plugin failures, i.e. the IMDS blip) → retried;
- errors carrying an API status → retried only when themselves transient (`ServerTimeout`, `Timeout`, `TooManyRequests`, `InternalError`, `ServiceUnavailable`);
- genuine auth/config failures (`401`/`403`) → fail fast.

The namespace apply is the first, and so most exposed, API-server call; once the exec credential is obtained it is cached by client-go, so later calls in the same deploy reuse it.

### Why

A single IMDS/network blip should not fail an otherwise-healthy prod rollout step and force a full restart (which also wastes the forced 2-minute failure sleep on the EV2 agent).

### Testing

- `go test ./...` in `tools/helm` — new `retry_test.go` covers: credential-plugin/transport errors and transient API statuses are retried; `401` fails fast; retry-then-succeed and fail-fast paths for `retryOnTransientCredentialError`.
- `go build ./...`, `gofmt -l`, `go vet ./...`, and `go tool golangci-lint run ./...` (0 issues) all clean.

### Special notes for your reviewer

Retry is intentionally anchored on the namespace apply rather than every API call, since the exec credential is cached after the first successful token mint. If reviewers prefer broader coverage I can hoist the helper around the history/helm-install calls too.

### PR Checklist

- [x] Tests added/updated
- [x] Lint/build/vet pass
- [x] Linked to Jira AROSLSRE-1234
