### PR TITLE
fix(grafanactl): reconcile stale URLs and delete orphaned Grafana datasources

### DIFF
--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -147,21 +147,23 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasourceURLs(ctx context.Cont
 			continue
 		}
 
-		logger.Info("Datasource URL is stale, updating",
+		if o.DryRun {
+			logger.Info("Dry run - would update stale datasource URL",
+				"datasource-name", ds.Name,
+				"current-url", ds.URL,
+				"expected-url", expectedEndpoint)
+			continue
+		}
+
+		logger.Info("Updating stale datasource URL",
 			"datasource-name", ds.Name,
 			"current-url", ds.URL,
 			"expected-url", expectedEndpoint)
-
-		if o.DryRun {
-			continue
-		}
 
 		ds.URL = expectedEndpoint
 		if err := o.GrafanaClient.UpdateDataSource(ctx, ds); err != nil {
 			return fmt.Errorf("failed to update datasource %q URL: %w", ds.Name, err)
 		}
-
-		logger.Info("Updated datasource URL", "datasource-name", ds.Name, "new-url", expectedEndpoint)
 	}
 
 	return nil

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -138,11 +138,12 @@ func getWorkspaceEndpoints(workspaces []armmonitor.AzureMonitorWorkspaceResource
 			workspace.Properties.Metrics.PrometheusQueryEndpoint == nil {
 			continue
 		}
-		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
-			name := strings.ToLower(*workspace.Name)
-			endpoints[name] = *workspace.Properties.Metrics.PrometheusQueryEndpoint
-			logger.Info("Found workspace endpoint", "workspace-name", *workspace.Name, "endpoint", endpoints[name])
+		if isTerminalFailureState(*workspace.Properties.ProvisioningState) {
+			continue
 		}
+		name := strings.ToLower(*workspace.Name)
+		endpoints[name] = *workspace.Properties.Metrics.PrometheusQueryEndpoint
+		logger.Info("Found workspace endpoint", "workspace-name", *workspace.Name, "endpoint", endpoints[name])
 	}
 
 	return endpoints

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -154,7 +154,7 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context
 		return fmt.Errorf("failed to list Grafana datasources: %w", err)
 	}
 
-	var deleteErrors error
+	var reconcileErrors error
 	for _, ds := range datasources {
 		if ds.Type != "prometheus" {
 			continue
@@ -175,7 +175,7 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context
 
 			logger.Info("Deleting orphaned datasource", "datasource-name", ds.Name)
 			if err := o.GrafanaClient.DeleteDataSource(ctx, ds.Name); err != nil {
-				deleteErrors = errors.Join(deleteErrors, fmt.Errorf("failed to delete datasource %q: %w", ds.Name, err))
+				reconcileErrors = errors.Join(reconcileErrors, fmt.Errorf("failed to delete datasource %q: %w", ds.Name, err))
 			}
 			continue
 		}
@@ -206,12 +206,12 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context
 
 		ds.URL = expectedEndpoint
 		if err := o.GrafanaClient.UpdateDataSource(ctx, ds); err != nil {
-			return fmt.Errorf("failed to update datasource %q URL: %w", ds.Name, err)
+			reconcileErrors = errors.Join(reconcileErrors, fmt.Errorf("failed to update datasource %q URL: %w", ds.Name, err))
 		}
 	}
 
-	if deleteErrors != nil {
-		return fmt.Errorf("failed to delete orphaned datasources: %w", deleteErrors)
+	if reconcileErrors != nil {
+		return fmt.Errorf("failed to reconcile datasources: %w", reconcileErrors)
 	}
 
 	return nil

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -101,6 +101,21 @@ func getMatchingWorkspaceIDs(workspaces []armmonitor.AzureMonitorWorkspaceResour
 	return validWorkspaceIDs
 }
 
+func getActiveWorkspaceNames(workspaces []armmonitor.AzureMonitorWorkspaceResource) set.Set[string] {
+	names := set.New[string]()
+
+	for _, workspace := range workspaces {
+		if workspace.Name == nil || workspace.Properties == nil || workspace.Properties.ProvisioningState == nil {
+			continue
+		}
+		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
+			names.Insert(strings.ToLower(*workspace.Name))
+		}
+	}
+
+	return names
+}
+
 func getWorkspaceEndpoints(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) map[string]string {
 	endpoints := make(map[string]string)
 
@@ -121,7 +136,7 @@ func getWorkspaceEndpoints(workspaces []armmonitor.AzureMonitorWorkspaceResource
 	return endpoints
 }
 
-func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context, logger logr.Logger, workspaceEndpoints map[string]string) error {
+func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context, logger logr.Logger, activeWorkspaceNames set.Set[string], workspaceEndpoints map[string]string) error {
 	datasources, err := o.GrafanaClient.ListDataSources(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list Grafana datasources: %w", err)
@@ -138,8 +153,9 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context
 			continue
 		}
 
-		expectedEndpoint, ok := workspaceEndpoints[strings.ToLower(workspaceName)]
-		if !ok {
+		lowerName := strings.ToLower(workspaceName)
+
+		if !activeWorkspaceNames.Has(lowerName) {
 			if o.DryRun {
 				logger.Info("Dry run - would delete orphaned datasource", "datasource-name", ds.Name)
 				continue
@@ -149,6 +165,12 @@ func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context
 			if err := o.GrafanaClient.DeleteDataSource(ctx, ds.Name); err != nil {
 				deleteErrors = errors.Join(deleteErrors, fmt.Errorf("failed to delete datasource %q: %w", ds.Name, err))
 			}
+			continue
+		}
+
+		expectedEndpoint, ok := workspaceEndpoints[lowerName]
+		if !ok {
+			logger.Info("Workspace exists but has no Prometheus endpoint yet, skipping", "datasource-name", ds.Name)
 			continue
 		}
 
@@ -231,10 +253,11 @@ func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
 		}
 	}
 
+	activeWorkspaceNames := getActiveWorkspaceNames(monitorWorkspaces)
 	workspaceEndpoints := getWorkspaceEndpoints(monitorWorkspaces, logger)
 
 	logger.Info("Reconciling datasources")
-	if err := o.reconcileDatasources(ctx, logger, workspaceEndpoints); err != nil {
+	if err := o.reconcileDatasources(ctx, logger, activeWorkspaceNames, workspaceEndpoints); err != nil {
 		return fmt.Errorf("failed to reconcile datasources: %w", err)
 	}
 

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -16,6 +16,7 @@ package modify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -84,15 +85,10 @@ func (opts *RawAddDatasourceOptions) Run(ctx context.Context) error {
 	return completed.Run(ctx)
 }
 
-func (o *CompletedAddDatasourceOptions) getMatchingWorkspaceIDs(ctx context.Context, logger logr.Logger) (set.Set[string], error) {
+func getMatchingWorkspaceIDs(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) set.Set[string] {
 	validWorkspaceIDs := set.New[string]()
 
-	monitorWorkspaces, err := o.MonitorWorkspaceClient.GetAllMonitorWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Azure Monitor Workspaces: %w", err)
-	}
-
-	for _, workspace := range monitorWorkspaces {
+	for _, workspace := range workspaces {
 		if workspace.Properties == nil || workspace.Properties.ProvisioningState == nil || workspace.ID == nil {
 			continue
 		}
@@ -102,7 +98,89 @@ func (o *CompletedAddDatasourceOptions) getMatchingWorkspaceIDs(ctx context.Cont
 		}
 	}
 
-	return validWorkspaceIDs, nil
+	return validWorkspaceIDs
+}
+
+func getWorkspaceEndpoints(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) map[string]string {
+	endpoints := make(map[string]string)
+
+	for _, workspace := range workspaces {
+		if workspace.Name == nil || workspace.Properties == nil ||
+			workspace.Properties.ProvisioningState == nil ||
+			workspace.Properties.Metrics == nil ||
+			workspace.Properties.Metrics.PrometheusQueryEndpoint == nil {
+			continue
+		}
+		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
+			name := strings.ToLower(*workspace.Name)
+			endpoints[name] = *workspace.Properties.Metrics.PrometheusQueryEndpoint
+			logger.Info("Found workspace endpoint", "workspace-name", *workspace.Name, "endpoint", endpoints[name])
+		}
+	}
+
+	return endpoints
+}
+
+func (o *CompletedAddDatasourceOptions) reconcileDatasources(ctx context.Context, logger logr.Logger, workspaceEndpoints map[string]string) error {
+	datasources, err := o.GrafanaClient.ListDataSources(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list Grafana datasources: %w", err)
+	}
+
+	var deleteErrors error
+	for _, ds := range datasources {
+		if ds.Type != "prometheus" {
+			continue
+		}
+
+		workspaceName := strings.TrimPrefix(ds.Name, "Managed_Prometheus_")
+		if workspaceName == ds.Name {
+			continue
+		}
+
+		expectedEndpoint, ok := workspaceEndpoints[strings.ToLower(workspaceName)]
+		if !ok {
+			if o.DryRun {
+				logger.Info("Dry run - would delete orphaned datasource", "datasource-name", ds.Name)
+				continue
+			}
+
+			logger.Info("Deleting orphaned datasource", "datasource-name", ds.Name)
+			if err := o.GrafanaClient.DeleteDataSource(ctx, ds.Name); err != nil {
+				deleteErrors = errors.Join(deleteErrors, fmt.Errorf("failed to delete datasource %q: %w", ds.Name, err))
+			}
+			continue
+		}
+
+		if ds.URL == expectedEndpoint {
+			logger.Info("Datasource URL is current", "datasource-name", ds.Name, "url", ds.URL)
+			continue
+		}
+
+		if o.DryRun {
+			logger.Info("Dry run - would update stale datasource URL",
+				"datasource-name", ds.Name,
+				"current-url", ds.URL,
+				"expected-url", expectedEndpoint)
+			continue
+		}
+
+		logger.Info("Updating stale datasource URL",
+			"datasource-name", ds.Name,
+			"current-url", ds.URL,
+			"expected-url", expectedEndpoint)
+
+		ds.URL = expectedEndpoint
+		if err := o.GrafanaClient.UpdateDataSource(ctx, ds); err != nil {
+			return fmt.Errorf("failed to update datasource %q URL: %w", ds.Name, err)
+		}
+	}
+
+	if deleteErrors != nil {
+		return fmt.Errorf("failed to delete orphaned datasources: %w", deleteErrors)
+	}
+
+	return nil
 }
 
 func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
@@ -115,10 +193,12 @@ func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get Grafana instance: %w", err)
 	}
 
-	validWorkspaceIDs, err := o.getMatchingWorkspaceIDs(ctx, logger)
+	monitorWorkspaces, err := o.MonitorWorkspaceClient.GetAllMonitorWorkspaces(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get valid workspace IDs: %w", err)
+		return fmt.Errorf("failed to list Azure Monitor Workspaces: %w", err)
 	}
+
+	validWorkspaceIDs := getMatchingWorkspaceIDs(monitorWorkspaces, logger)
 
 	integrationList := set.New[string]()
 	for _, integration := range grafana.Properties.GrafanaIntegrations.AzureMonitorWorkspaceIntegrations {
@@ -142,14 +222,20 @@ func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
 
 	if o.DryRun {
 		logger.Info("Dry run - would reconcile Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
-		return nil
+	} else {
+		logger.Info("Reconciling Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
+
+		err = o.ManagedGrafanaClient.UpdateGrafanaIntegrations(ctx, o.ResourceGroup, o.GrafanaName, integrationList.UnsortedList())
+		if err != nil {
+			return fmt.Errorf("failed to update Grafana integrations: %w", err)
+		}
 	}
 
-	logger.Info("Reconciling Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
+	workspaceEndpoints := getWorkspaceEndpoints(monitorWorkspaces, logger)
 
-	err = o.ManagedGrafanaClient.UpdateGrafanaIntegrations(ctx, o.ResourceGroup, o.GrafanaName, integrationList.UnsortedList())
-	if err != nil {
-		return fmt.Errorf("failed to update Grafana integrations: %w", err)
+	logger.Info("Reconciling datasources")
+	if err := o.reconcileDatasources(ctx, logger, workspaceEndpoints); err != nil {
+		return fmt.Errorf("failed to reconcile datasources: %w", err)
 	}
 
 	return nil

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -84,15 +84,10 @@ func (opts *RawAddDatasourceOptions) Run(ctx context.Context) error {
 	return completed.Run(ctx)
 }
 
-func (o *CompletedAddDatasourceOptions) getMatchingWorkspaceIDs(ctx context.Context, logger logr.Logger) (set.Set[string], error) {
+func getMatchingWorkspaceIDs(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) set.Set[string] {
 	validWorkspaceIDs := set.New[string]()
 
-	monitorWorkspaces, err := o.MonitorWorkspaceClient.GetAllMonitorWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Azure Monitor Workspaces: %w", err)
-	}
-
-	for _, workspace := range monitorWorkspaces {
+	for _, workspace := range workspaces {
 		if workspace.Properties == nil || workspace.Properties.ProvisioningState == nil || workspace.ID == nil {
 			continue
 		}
@@ -102,7 +97,74 @@ func (o *CompletedAddDatasourceOptions) getMatchingWorkspaceIDs(ctx context.Cont
 		}
 	}
 
-	return validWorkspaceIDs, nil
+	return validWorkspaceIDs
+}
+
+func getWorkspaceEndpoints(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) map[string]string {
+	endpoints := make(map[string]string)
+
+	for _, workspace := range workspaces {
+		if workspace.Name == nil || workspace.Properties == nil ||
+			workspace.Properties.ProvisioningState == nil ||
+			workspace.Properties.Metrics == nil ||
+			workspace.Properties.Metrics.PrometheusQueryEndpoint == nil {
+			continue
+		}
+		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
+			name := strings.ToLower(*workspace.Name)
+			endpoints[name] = *workspace.Properties.Metrics.PrometheusQueryEndpoint
+			logger.Info("Found workspace endpoint", "workspace-name", *workspace.Name, "endpoint", endpoints[name])
+		}
+	}
+
+	return endpoints
+}
+
+func (o *CompletedAddDatasourceOptions) reconcileDatasourceURLs(ctx context.Context, logger logr.Logger, workspaceEndpoints map[string]string) error {
+	datasources, err := o.GrafanaClient.ListDataSources(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list Grafana datasources: %w", err)
+	}
+
+	for _, ds := range datasources {
+		if ds.Type != "prometheus" {
+			continue
+		}
+
+		workspaceName := strings.TrimPrefix(ds.Name, "Managed_Prometheus_")
+		if workspaceName == ds.Name {
+			continue
+		}
+
+		expectedEndpoint, ok := workspaceEndpoints[strings.ToLower(workspaceName)]
+		if !ok {
+			logger.Info("No matching workspace found for datasource, skipping URL check", "datasource-name", ds.Name)
+			continue
+		}
+
+		if ds.URL == expectedEndpoint {
+			logger.Info("Datasource URL is current", "datasource-name", ds.Name, "url", ds.URL)
+			continue
+		}
+
+		logger.Info("Datasource URL is stale, updating",
+			"datasource-name", ds.Name,
+			"current-url", ds.URL,
+			"expected-url", expectedEndpoint)
+
+		if o.DryRun {
+			continue
+		}
+
+		ds.URL = expectedEndpoint
+		if err := o.GrafanaClient.UpdateDataSource(ctx, ds); err != nil {
+			return fmt.Errorf("failed to update datasource %q URL: %w", ds.Name, err)
+		}
+
+		logger.Info("Updated datasource URL", "datasource-name", ds.Name, "new-url", expectedEndpoint)
+	}
+
+	return nil
 }
 
 func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
@@ -115,10 +177,12 @@ func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get Grafana instance: %w", err)
 	}
 
-	validWorkspaceIDs, err := o.getMatchingWorkspaceIDs(ctx, logger)
+	monitorWorkspaces, err := o.MonitorWorkspaceClient.GetAllMonitorWorkspaces(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get valid workspace IDs: %w", err)
+		return fmt.Errorf("failed to list Azure Monitor Workspaces: %w", err)
 	}
+
+	validWorkspaceIDs := getMatchingWorkspaceIDs(monitorWorkspaces, logger)
 
 	integrationList := set.New[string]()
 	for _, integration := range grafana.Properties.GrafanaIntegrations.AzureMonitorWorkspaceIntegrations {
@@ -142,14 +206,20 @@ func (o *CompletedAddDatasourceOptions) Run(ctx context.Context) error {
 
 	if o.DryRun {
 		logger.Info("Dry run - would reconcile Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
-		return nil
+	} else {
+		logger.Info("Reconciling Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
+
+		err = o.ManagedGrafanaClient.UpdateGrafanaIntegrations(ctx, o.ResourceGroup, o.GrafanaName, integrationList.UnsortedList())
+		if err != nil {
+			return fmt.Errorf("failed to update Grafana integrations: %w", err)
+		}
 	}
 
-	logger.Info("Reconciling Azure Monitor Workspace integrations", "total-integrations", integrationList.Len())
+	workspaceEndpoints := getWorkspaceEndpoints(monitorWorkspaces, logger)
 
-	err = o.ManagedGrafanaClient.UpdateGrafanaIntegrations(ctx, o.ResourceGroup, o.GrafanaName, integrationList.UnsortedList())
-	if err != nil {
-		return fmt.Errorf("failed to update Grafana integrations: %w", err)
+	logger.Info("Reconciling datasource URLs")
+	if err := o.reconcileDatasourceURLs(ctx, logger, workspaceEndpoints); err != nil {
+		return fmt.Errorf("failed to reconcile datasource URLs: %w", err)
 	}
 
 	return nil

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -85,6 +85,15 @@ func (opts *RawAddDatasourceOptions) Run(ctx context.Context) error {
 	return completed.Run(ctx)
 }
 
+func isTerminalFailureState(state armmonitor.ProvisioningState) bool {
+	switch state {
+	case armmonitor.ProvisioningStateFailed, armmonitor.ProvisioningStateCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
 func getMatchingWorkspaceIDs(workspaces []armmonitor.AzureMonitorWorkspaceResource, logger logr.Logger) set.Set[string] {
 	validWorkspaceIDs := set.New[string]()
 
@@ -92,10 +101,13 @@ func getMatchingWorkspaceIDs(workspaces []armmonitor.AzureMonitorWorkspaceResour
 		if workspace.Properties == nil || workspace.Properties.ProvisioningState == nil || workspace.ID == nil {
 			continue
 		}
-		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
-			logger.Info("Found", "workspace-id", *workspace.ID, "provisioning-state", *workspace.Properties.ProvisioningState)
-			validWorkspaceIDs.Insert(strings.ToLower(*workspace.ID))
+		state := *workspace.Properties.ProvisioningState
+		if isTerminalFailureState(state) {
+			logger.Info("Skipping workspace in terminal failure state", "workspace-id", *workspace.ID, "provisioning-state", state)
+			continue
 		}
+		logger.Info("Found", "workspace-id", *workspace.ID, "provisioning-state", state)
+		validWorkspaceIDs.Insert(strings.ToLower(*workspace.ID))
 	}
 
 	return validWorkspaceIDs
@@ -108,7 +120,7 @@ func getActiveWorkspaceNames(workspaces []armmonitor.AzureMonitorWorkspaceResour
 		if workspace.Name == nil || workspace.Properties == nil || workspace.Properties.ProvisioningState == nil {
 			continue
 		}
-		if *workspace.Properties.ProvisioningState == armmonitor.ProvisioningStateSucceeded {
+		if !isTerminalFailureState(*workspace.Properties.ProvisioningState) {
 			names.Insert(strings.ToLower(*workspace.Name))
 		}
 	}

--- a/tools/grafanactl/cmd/modify/cmd.go
+++ b/tools/grafanactl/cmd/modify/cmd.go
@@ -117,12 +117,10 @@ func getActiveWorkspaceNames(workspaces []armmonitor.AzureMonitorWorkspaceResour
 	names := set.New[string]()
 
 	for _, workspace := range workspaces {
-		if workspace.Name == nil || workspace.Properties == nil || workspace.Properties.ProvisioningState == nil {
+		if workspace.Name == nil {
 			continue
 		}
-		if !isTerminalFailureState(*workspace.Properties.ProvisioningState) {
-			names.Insert(strings.ToLower(*workspace.Name))
-		}
+		names.Insert(strings.ToLower(*workspace.Name))
 	}
 
 	return names

--- a/tools/grafanactl/cmd/modify/options.go
+++ b/tools/grafanactl/cmd/modify/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/ARO-Tools/tools/cmdutils"
 	"github.com/Azure/ARO-Tools/tools/grafanactl/cmd/base"
 	"github.com/Azure/ARO-Tools/tools/grafanactl/internal/azure"
+	"github.com/Azure/ARO-Tools/tools/grafanactl/internal/grafana"
 )
 
 // RawAddDatasourceOptions represents the initial, unvalidated configuration for add datasource operations.
@@ -48,6 +49,7 @@ type ValidatedAddDatasourceOptions struct {
 // for add datasource operations.
 type CompletedAddDatasourceOptions struct {
 	*validatedAddDatasourceOptions
+	GrafanaClient          *grafana.Client
 	MonitorWorkspaceClient *azure.MonitorWorkspaceClient
 	ManagedGrafanaClient   *azure.ManagedGrafanaClient
 }
@@ -107,6 +109,11 @@ func (o *ValidatedAddDatasourceOptions) Complete(ctx context.Context) (*Complete
 		return nil, fmt.Errorf("failed to create managed Grafana client: %w", err)
 	}
 
+	grafanaClient, err := grafana.NewClient(ctx, cred, managedGrafanaClient, o.SubscriptionID, o.ResourceGroup, o.GrafanaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Grafana client: %w", err)
+	}
+
 	monitorWorkspaceClient, err := azure.NewMonitorWorkspaceClient(o.SubscriptionID, cred, clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create monitor workspace client: %w", err)
@@ -114,6 +121,7 @@ func (o *ValidatedAddDatasourceOptions) Complete(ctx context.Context) (*Complete
 
 	return &CompletedAddDatasourceOptions{
 		validatedAddDatasourceOptions: o.validatedAddDatasourceOptions,
+		GrafanaClient:                 grafanaClient,
 		MonitorWorkspaceClient:        monitorWorkspaceClient,
 		ManagedGrafanaClient:          managedGrafanaClient,
 	}, nil

--- a/tools/grafanactl/internal/grafana/client.go
+++ b/tools/grafanactl/internal/grafana/client.go
@@ -112,7 +112,7 @@ func (c *Client) DeleteDataSource(ctx context.Context, dataSourceName string) er
 func (c *Client) UpdateDataSource(ctx context.Context, ds sdk.Datasource) error {
 	_, err := c.grafanaClient.UpdateDatasource(ctx, ds)
 	if err != nil {
-		return fmt.Errorf("failed to update datasource: %w", err)
+		return fmt.Errorf("failed to update datasource %q (ID %d): %w", ds.Name, ds.ID, err)
 	}
 
 	return nil

--- a/tools/grafanactl/internal/grafana/client.go
+++ b/tools/grafanactl/internal/grafana/client.go
@@ -108,6 +108,16 @@ func (c *Client) DeleteDataSource(ctx context.Context, dataSourceName string) er
 	return nil
 }
 
+// UpdateDataSource updates a datasource in the Grafana instance.
+func (c *Client) UpdateDataSource(ctx context.Context, ds sdk.Datasource) error {
+	_, err := c.grafanaClient.UpdateDatasource(ctx, ds)
+	if err != nil {
+		return fmt.Errorf("failed to update datasource: %w", err)
+	}
+
+	return nil
+}
+
 // ListFolders returns all folders in the Grafana instance.
 func (c *Client) ListFolders(ctx context.Context) ([]sdk.Folder, error) {
 	folders, err := c.grafanaClient.GetAllFolders(ctx)


### PR DESCRIPTION
## Summary

- The `modify datasource reconcile` command only managed Azure Monitor Workspace integrations (resource IDs on the Grafana ARM resource) but never checked the actual datasource URLs or removed orphaned datasources in Grafana.
- After integration reconciliation, the command now:
  - **Updates stale datasource URLs** when the AMW `PrometheusQueryEndpoint` hostname has changed (fixes DNS resolution errors)
  - **Deletes orphaned `Managed_Prometheus_*` datasources** whose workspaces no longer exist (consolidates `clean fixup-datasources` logic into the pipeline step)
- Orphan detection uses workspace existence, not endpoint presence, to avoid a delete-recreate loop with workspaces that exist but haven't provisioned a Prometheus endpoint yet.
- Both operations respect `--dry-run`.

Fixes: [ARO-27914](https://issues.redhat.com/browse/ARO-27914), [AROSLSRE-1347](https://redhat.atlassian.net/browse/AROSLSRE-1347), [AROSLSRE-585](https://redhat.atlassian.net/browse/AROSLSRE-585)

## Test plan

- [x] `cd tools/grafanactl && go build ./...` — compiles cleanly
- [x] `cd tools/grafanactl && go vet ./...` — no issues
- [x] Dry-run against dev Grafana — correctly identifies stale URLs and orphaned datasources
- [x] Live run against dev Grafana — 24 stale URLs updated, 10 orphaned datasources deleted
- [x] Verification re-run — 0 stale, 0 orphaned, 49 current (idempotent)
- [ ] Verify dashboards still load after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)