### PR TITLE
feat(pipelines): add manage field to CreateCertificateStep (ARO-28053)

### DIFF
--- a/pipelines/testdata/config.yaml
+++ b/pipelines/testdata/config.yaml
@@ -29,6 +29,8 @@ defaults:
   clustersService:
     imageTag: abcdef
     replicas: 3
+  certificates:
+    manage: Enabled
   parentZone: example.com
   childZone: child.example.com
   vaultBaseUrl: myvault.azure.com

--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -160,6 +160,8 @@ resourceGroups:
       value: OneCertV2-PrivateCA
     commonName:
       value: hcp-mdsd.geneva.keyvault.aro-int.azure.com
+    manage:
+      configRef: certificates.manage
   - name: rpRegistration
     action: ResourceProviderRegistration
     resourceProviderNamespaces:

--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -228,17 +228,23 @@ func (s *SetCertificateIssuerStep) RequiredInputs() []StepDependency {
 
 const StepActionCreateCertificate = "CreateCertificate"
 
+const (
+	CertificateManageEnabled  = "Enabled"
+	CertificateManageDisabled = "Disabled"
+)
+
 type CreateCertificateStep struct {
 	StepMeta        `json:",inline"`
-	VaultBaseUrl    Value `json:"vaultBaseUrl,omitempty"`
-	CertificateName Value `json:"certificateName,omitempty"`
-	ContentType     Value `json:"contentType,omitempty"`
-	SAN             Value `json:"san,omitempty"`
-	Issuer          Value `json:"issuer,omitempty"`
-	SecretKeyVault  Value `json:"secretKeyVault,omitempty"`
-	SecretName      Value `json:"secretName,omitempty"`
-	ApplicationId   Value `json:"applicationId,omitempty"`
-	CommonName      Value `json:"commonName,omitempty"`
+	VaultBaseUrl    Value  `json:"vaultBaseUrl,omitempty"`
+	CertificateName Value  `json:"certificateName,omitempty"`
+	ContentType     Value  `json:"contentType,omitempty"`
+	SAN             Value  `json:"san,omitempty"`
+	Issuer          Value  `json:"issuer,omitempty"`
+	SecretKeyVault  Value  `json:"secretKeyVault,omitempty"`
+	SecretName      Value  `json:"secretName,omitempty"`
+	ApplicationId   Value  `json:"applicationId,omitempty"`
+	CommonName      Value  `json:"commonName,omitempty"`
+	Manage          *Value `json:"manage,omitempty"`
 }
 
 func (s *CreateCertificateStep) Description() string {
@@ -251,6 +257,9 @@ func (s *CreateCertificateStep) RequiredInputs() []StepDependency {
 		if val.Input != nil {
 			deps = append(deps, val.Input.StepDependency)
 		}
+	}
+	if s.Manage != nil && s.Manage.Input != nil {
+		deps = append(deps, s.Manage.Input.StepDependency)
 	}
 	slices.SortFunc(deps, SortDependencies)
 	deps = slices.Compact(deps)

--- a/pipelines/types/common_test.go
+++ b/pipelines/types/common_test.go
@@ -96,6 +96,7 @@ func TestRequiredInputs(t *testing.T) {
 				SecretName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step6"}}},
 				ApplicationId:   Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step7"}}},
 				CommonName:      Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step8"}}},
+				Manage:          &Value{ConfigRef: "some.config.manage"},
 			},
 			expected: []StepDependency{
 				{ResourceGroup: "rg", Step: "step"},

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -1020,6 +1020,9 @@
             },
             "commonName": {
               "$ref": "#/definitions/value"
+            },
+            "manage": {
+              "$ref": "#/definitions/value"
             }
           },
           "required": [

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -142,6 +142,8 @@ resourceGroups:
       value: x-pem-file
     issuer:
       value: OneCertV2-PrivateCA
+    manage:
+      configRef: certificates.manage
     name: cert
     san:
       value: hcp-mdsd.geneva.keyvault.aro-int.azure.com


### PR DESCRIPTION
## What
Allow disabling certificate management via an optional `manage` Value field. Value range `Enabled/Disabled`. Absence will be interpreted as enabled downstream.

## Why
Some environments (e.g. FPA and GA in DEV/INT) manage certificates differently, and the pipeline step needs to be skippable without removing it from the config.

https://redhat.atlassian.net/browse/ARO-28053