### PR TITLE
feat(pipelines): require shellIdentity on Shell steps in the schema (AROSLSRE-1380)

### DIFF
--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -451,7 +451,8 @@
         }
       },
       "required": [
-        "command"
+        "command",
+        "shellIdentity"
       ]
     },
     "shellStep": {

--- a/pipelines/types/pipeline_test.go
+++ b/pipelines/types/pipeline_test.go
@@ -79,6 +79,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: false,
 			description: "backfillSubscriptionId alone should be valid",
@@ -101,6 +103,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: false,
 			description: "displayName and roleAssignment alone should be valid",
@@ -124,6 +128,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: false,
 			description: "backfillSubscriptionId with displayName should be valid (new behavior)",
@@ -152,6 +158,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: false,
 			description: "backfillSubscriptionId with all other fields should be valid (new behavior)",
@@ -173,6 +181,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: true,
 			description: "missing both required patterns should fail validation",
@@ -194,6 +204,8 @@ resourceGroups:
   - name: deploy
     action: Shell
     command: echo hello
+    shellIdentity:
+      value: existing-msi
 `,
 			expectError: true,
 			description: "displayName without roleAssignment should fail validation",

--- a/pipelines/types/validation_test.go
+++ b/pipelines/types/validation_test.go
@@ -303,6 +303,9 @@ func TestValidatePipelineSchema(t *testing.T) {
 								"name":    "step",
 								"action":  "Shell",
 								"command": "echo hello",
+								"shellIdentity": map[string]interface{}{
+									"value": "test-msi",
+								},
 							},
 						},
 					},
@@ -325,6 +328,9 @@ func TestValidatePipelineSchema(t *testing.T) {
 								"action":  "Shell",
 								"command": "echo hello",
 								"timeout": "75m",
+								"shellIdentity": map[string]interface{}{
+									"value": "test-msi",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
## Problem

A `Shell` step's `shellIdentity` is effectively mandatory — sdp-pipelines EV2RA manifest generation validates it unconditionally and aborts if unset:

```text
step ...: error validating step:
invalid shell identity: variable must specify config ref, value, or input chain
```

But `shellStepBase` in `pipeline.schema.v1.json` only marks `command` as `required`, so consumers that validate against the schema (e.g. ARO-HCP `make validate-config-pipelines`) without running EV2RA generation accept Shell steps that omit an identity. They only fail later, at bump time — which just caused an ARO-HCP revert/reland ([Azure/ARO-HCP#5834](https://github.com/Azure/ARO-HCP/pull/5834) → [#5888](https://github.com/Azure/ARO-HCP/pull/5888) / [#5889](https://github.com/Azure/ARO-HCP/pull/5889)).

## What changes

Add `shellIdentity` to `shellStepBase.required`:

```json
"required": [
  "command",
  "shellIdentity"
]
```

This also covers `shellValidationStep`, which embeds the same base. The Go type (`shell.go`) already documented the field as required. Existing valid-shell test fixtures are updated to declare `shellIdentity`.

## Validation

- `go test ./pipelines/types/...` passes (schema + fixtures). The `pipelines/graph` failures in this environment are only missing `graphviz`/`dot`, unrelated to this change.

## Follow-ups

- Un-hold once ARO-HCP is compliant (reland [#5889](https://github.com/Azure/ARO-HCP/pull/5889) + hardening [#5890](https://github.com/Azure/ARO-HCP/pull/5890)).
- Optional: improve the runtime error to name the step and say `shellIdentity is required`.
