### PR TITLE
Istio phase support

### DIFF
--- a/pipelines/types/istio.go
+++ b/pipelines/types/istio.go
@@ -22,10 +22,18 @@ type IstioUpgradeStep struct {
 	StepMeta   `json:",inline"`
 	AKSCluster string `json:"aksCluster"`
 	DryRun     bool   `json:"dryRun,omitempty"`
+	// "install" installs the new control plane alongside the existing one
+	// and stops before workload migration. "upgrade" migrates workloads and
+	// completes the canary. Empty runs the full lifecycle in one step.
+	Phase string `json:"phase,omitempty"`
 }
 
 func (s *IstioUpgradeStep) Description() string {
-	return fmt.Sprintf("Step %s\n  Kind: %s\n  AKSCluster: %s\n  DryRun: %v\n", s.Name, s.Action, s.AKSCluster, s.DryRun)
+	phase := s.Phase
+	if phase == "" {
+		phase = "full"
+	}
+	return fmt.Sprintf("Step %s\n  Kind: %s\n  AKSCluster: %s\n  DryRun: %v\n  Phase: %s\n", s.Name, s.Action, s.AKSCluster, s.DryRun, phase)
 }
 
 func (s *IstioUpgradeStep) RequiredInputs() []StepDependency {

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -820,6 +820,37 @@
         }
       ]
     },
+    "istioUpgradeStep": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/stepMeta"
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "IstioUpgrade"
+            },
+            "aksCluster": {
+              "type": "string"
+            },
+            "dryRun": {
+              "type": "boolean"
+            },
+            "phase": {
+              "type": "string",
+              "enum": [
+                "install",
+                "upgrade"
+              ]
+            }
+          },
+          "required": [
+            "aksCluster"
+          ]
+        }
+      ]
+    },
     "helmStep": {
       "unevaluatedProperties": false,
       "allOf": [
@@ -2072,6 +2103,22 @@
                   },
                   "then": {
                     "$ref": "#/definitions/grafanaDatasourcesStep"
+                  }
+                },
+                {
+                  "if": {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "const": "IstioUpgrade"
+                      }
+                    },
+                    "required": [
+                      "action"
+                    ]
+                  },
+                  "then": {
+                    "$ref": "#/definitions/istioUpgradeStep"
                   }
                 }
               ],


### PR DESCRIPTION
  ## Summary

  - Add `Phase` field to `IstioUpgradeStep` enabling the ability to split Istio upgrades into discrete steps with `dependsOn` chaining
  - `install` installs the new control plane alongside the existing one and stops before workload migration
  - `upgrade` migrates workloads and completes the canary
  - Omitting phase, runs the full lifecycle in one step
  - The upgrade can run as a single step, but the `Phase` field allows splitting it into separate pipeline steps with other actions (e.g. Helm config) in between                             
  - Splitting also gives each phase its own EV2 timeout budget — a single step must fit ARM operations, workload migration, and rollout convergence into one timeout window
  - Include `Phase` in `Description()` output for pipeline log visibility

  ## Context
  
  Without the phase field change, the `IstioUpgradeStep` would run the entire upgrade lifecycle in a single step. With `Phase`,
  we can insert a Helm config step between control plane installation and workload migration —
  matching the `istio-canary → istio-config → istio-rollout` pattern in `svc-pipeline.yaml` in a
  future release.