### PR TITLE
feat: enable Explore in all Grafanas

### DIFF
--- a/tools/grafanactl/cmd/manage/cmd.go
+++ b/tools/grafanactl/cmd/manage/cmd.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/set"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2"
 )
 
@@ -133,6 +134,11 @@ func (o *CompletedReconcileOptions) Run(ctx context.Context) error {
 		Tags: tags,
 		Properties: &armdashboard.ManagedGrafanaProperties{
 			ZoneRedundancy: &zoneRedundancy,
+			GrafanaConfigurations: &armdashboard.GrafanaConfigurations{
+				Users: &armdashboard.Users{
+					ViewersCanEdit: to.Ptr(true),
+				},
+			},
 			GrafanaIntegrations: &armdashboard.GrafanaIntegrations{
 				AzureMonitorWorkspaceIntegrations: integrations,
 			},


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1399

## Why
ARO HCP wants Grafana Viewer-role users to access Explore without granting persistent Editor permissions. Azure Managed Grafana supports this through `grafanaConfigurations.users.viewersCanEdit`.

## What
- Always sets `properties.grafanaConfigurations.users.viewersCanEdit` to `true` when `grafanactl manage reconcile` creates or updates an Azure Managed Grafana instance.
- Works on top of (some future iteration of) https://github.com/Azure/ARO-HCP/pull/5933

## Validation
```
[vault@csb claude/pr-5933 (pr-5933)]$ az rest --method GET     --url "https://management.azure.com/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.Dashboard/grafana/mmazurtesting?api-version=2025-08-01"     --query "properties.grafanaConfigurations.users" -o json
[vault@csb claude/pr-5933 (pr-5933)]$ OVERRIDE_CONFIG_FILE=/tmp/grafana-override.yaml make pipeline/Grafana
make local-run WHAT="--service-group Microsoft.Azure.ARO.HCP.Grafana"
make[1]: Entering directory '/home/vault/work/claude/pr-5933'
(…)
make[1]: Leaving directory '/home/vault/work/claude/pr-5933'
[vault@csb claude/pr-5933 (pr-5933)]$ az rest --method GET     --url "https://management.azure.com/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourceGroups/global/providers/Microsoft.Dashboard/grafana/mmazurtesting?api-version=2025-08-01"     --query "properties.grafanaConfigurations.users" -o json
{
  "viewersCanEdit": true
}
```

<img width="1294" height="1339" alt="Screenshot_20260708_160251-1" src="https://github.com/user-attachments/assets/64838212-b63c-45d5-8ad6-967eec5d33a9" />

