### PR TITLE
Add Get Accounts geneva action for pav2

### DIFF
--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -1142,6 +1142,10 @@
                 {
                   "const": "ManageAppId",
                   "description": "Manage the application ID"
+                },
+                {
+                  "const": "GetAccount",
+                  "description": "Get Pav2 Account(s)"
                 }
               ]
             },
@@ -1213,6 +1217,22 @@
                   "secretKeyVault",
                   "secretName",
                   "smeAppidParameter"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "GetAccount"
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "operation",
+                  "secretKeyVault",
+                  "secretName"
                 ]
               }
             }


### PR DESCRIPTION
We want to utilize PAv2's `Get Accounts` geneva action to ensure our PAv2 registration worked before we try to deploy our app.