### PR TITLE
add SafeFly step schema definition

### DIFF
--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -519,6 +519,10 @@ resourceGroups:
         resourceGroup: regional
         step: deploy
         name: whatever
+    - name: safefly-submit
+      action: SafeFly
+      shellIdentity:
+        configRef: aroDevopsMsiId
   validationSteps:
   - name: e2e
     action: ProwJob

--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -171,6 +171,30 @@ type DryRun struct {
 	Command   string     `json:"command,omitempty"`
 }
 
+const StepActionSafeFly = "SafeFly"
+
+// SafeFlyStep submits a SafeFly request for the current rollout.
+type SafeFlyStep struct {
+	StepMeta      `json:",inline"`
+	ShellIdentity Value `json:"shellIdentity"`
+}
+
+func (s *SafeFlyStep) Description() string {
+	return fmt.Sprintf("Step %s\n  Kind: %s\n", s.Name, s.Action)
+}
+
+func (s *SafeFlyStep) RequiredInputs() []StepDependency {
+	if s.ShellIdentity.Input == nil {
+		return nil
+	}
+	return []StepDependency{s.ShellIdentity.Input.StepDependency}
+}
+
+// IsWellFormedOverInputs returns false because the current rollout is an implicit input.
+func (s *SafeFlyStep) IsWellFormedOverInputs() bool {
+	return false
+}
+
 const StepActionDelegateChildZone = "DelegateChildZone"
 
 type DelegateChildZoneStep struct {

--- a/pipelines/types/common_test.go
+++ b/pipelines/types/common_test.go
@@ -33,6 +33,19 @@ func TestRequiredInputs(t *testing.T) {
 			input: &ShellStep{},
 		},
 		{
+			name: "safefly full",
+			input: &SafeFlyStep{
+				ShellIdentity: Value{Input: &Input{StepDependency: StepDependency{ResourceGroup: "rg", Step: "step"}}},
+			},
+			expected: []StepDependency{
+				{ResourceGroup: "rg", Step: "step"},
+			},
+		},
+		{
+			name:  "safefly empty",
+			input: &SafeFlyStep{},
+		},
+		{
 			name: "arm full",
 			input: &ARMStep{
 				Variables: []Variable{
@@ -342,6 +355,7 @@ func TestIsWellFormedOverInputs(t *testing.T) {
 	}{
 		{in: &ShellStep{}, expected: false},
 		{in: &ShellStep{WorkingDir: "something"}, expected: true},
+		{in: &SafeFlyStep{}, expected: false},
 		{in: &HelmStep{}, expected: true},
 		{in: &ARMStep{}, expected: true},
 		{in: &ARMStackStep{}, expected: true},

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -468,6 +468,27 @@
         }
       ]
     },
+    "safeFlyStep": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/stepMeta"
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "SafeFly"
+            },
+            "shellIdentity": {
+              "$ref": "#/definitions/value"
+            }
+          },
+          "required": [
+            "shellIdentity"
+          ]
+        }
+      ]
+    },
     "shellValidationStep": {
       "unevaluatedProperties": false,
       "allOf": [
@@ -1765,6 +1786,22 @@
                   },
                   "then": {
                     "$ref": "#/definitions/shellStep"
+                  }
+                },
+                {
+                  "if": {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "const": "SafeFly"
+                      }
+                    },
+                    "required": [
+                      "action"
+                    ]
+                  },
+                  "then": {
+                    "$ref": "#/definitions/safeFlyStep"
                   }
                 },
                 {

--- a/pipelines/types/resourcegroup.go
+++ b/pipelines/types/resourcegroup.go
@@ -102,6 +102,8 @@ func (s *Steps) UnmarshalJSON(data []byte) error {
 		switch stepMeta.Action {
 		case StepActionShell:
 			step = &ShellStep{}
+		case StepActionSafeFly:
+			step = &SafeFlyStep{}
 		case StepActionHelm:
 			step = &HelmStep{}
 		case StepActionARM:

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -538,6 +538,10 @@ resourceGroups:
       resourceGroup: regional
       step: deploy
     name: datasources
+  - action: SafeFly
+    name: safefly-submit
+    shellIdentity:
+      configRef: aroDevopsMsiId
   subscription: hcp-uksouth
   subscriptionProvisioning:
     displayName:

--- a/pipelines/types/validation_test.go
+++ b/pipelines/types/validation_test.go
@@ -338,6 +338,50 @@ func TestValidatePipelineSchema(t *testing.T) {
 			},
 		},
 		{
+			name: "valid safefly",
+			pipeline: map[string]interface{}{
+				"serviceGroup": "test",
+				"rolloutName":  "test",
+				"resourceGroups": []interface{}{
+					map[string]interface{}{
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
+						"steps": []interface{}{
+							map[string]interface{}{
+								"name":   "step",
+								"action": "SafeFly",
+								"shellIdentity": map[string]interface{}{
+									"configRef": "safeFlyMsiId",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid safefly missing shell identity",
+			pipeline: map[string]interface{}{
+				"serviceGroup": "test",
+				"rolloutName":  "test",
+				"resourceGroups": []interface{}{
+					map[string]interface{}{
+						"name":          "rg",
+						"resourceGroup": "rg",
+						"subscription":  "sub",
+						"steps": []interface{}{
+							map[string]interface{}{
+								"name":   "step",
+								"action": "SafeFly",
+							},
+						},
+					},
+				},
+			},
+			err: "pipeline is not compliant with schema pipeline.schema.v1",
+		},
+		{
 			name: "invalid shell timeout",
 			pipeline: map[string]interface{}{
 				"serviceGroup": "test",


### PR DESCRIPTION
## What

Add a first-class SafeFly pipeline action so consumers can handle SafeFly submissions as a distinct step type rather than pattern-matching on a Shell step's command.

## Why

Feedback pointed out that command sniffing is a step-type design smell. Once behavior branches on "is this doing this very specific thing?", it should be its own step type. This PR makes SafeFly a distinct action so consumers can dispatch on type instead of parsing command text.

## Testing

- `go test ./types` passes.
- Added test cases for the new step