### PR TITLE
feat(pipelines): add allowedSubscriptions to ProwJob step

### DIFF
--- a/pipelines/types/common.go
+++ b/pipelines/types/common.go
@@ -713,14 +713,15 @@ const StepActionProwJob = "ProwJob"
 type ProwJobStep struct {
 	StepMeta `json:",inline"`
 
-	TokenKeyvault string `json:"tokenKeyvault"`
-	TokenSecret   string `json:"tokenSecret"`
-	JobName       string `json:"jobName"`
-	GatePromotion string `json:"gatePromotion"`     // string-encoded boolean, passed to command as a flag
-	Commit        string `json:"commit,omitempty"`  // optional source commit SHA to pin the Prow job to
-	Repo          string `json:"repo,omitempty"`    // optional GitHub repo name override (default: ARO-HCP)
-	BaseRef       string `json:"baseRef,omitempty"` // optional Git base ref override (default: main)
-	DryRun        Value  `json:"dryRun,omitempty"`
+	TokenKeyvault        string `json:"tokenKeyvault"`
+	TokenSecret          string `json:"tokenSecret"`
+	JobName              string `json:"jobName"`
+	GatePromotion        string `json:"gatePromotion"`                  // string-encoded boolean, passed to command as a flag
+	AllowedSubscriptions string `json:"allowedSubscriptions,omitempty"` // optional slot-manager subscription allowlist override; see slot-manager docs
+	Commit               string `json:"commit,omitempty"`               // optional source commit SHA to pin the Prow job to
+	Repo                 string `json:"repo,omitempty"`                 // optional GitHub repo name override (default: ARO-HCP)
+	BaseRef              string `json:"baseRef,omitempty"`              // optional Git base ref override (default: main)
+	DryRun               Value  `json:"dryRun,omitempty"`
 
 	// IdentityFrom specifies the managed identity with which this deployment will run in Ev2.
 	IdentityFrom Input `json:"identityFrom,omitempty"`

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -706,6 +706,9 @@
             "gatePromotion": {
               "type": "string"
             },
+            "allowedSubscriptions": {
+              "type": "string"
+            },
             "commit": {
               "type": "string"
             },


### PR DESCRIPTION
## Why

The PROD ARO-HCP e2e gating job is moving to a single slot-manager-driven job that spans two Azure tenants. The canary region (`eastus2euap`) must run against the **MSFT Test-Tenant** subscription — currently the only subscription onboarded into the canary program — while all other PROD regions run against the RH-tenant PROD subscriptions.

To route per region, the pipeline needs to pass a per-region `ALLOWED_SUBSCRIPTIONS` override to the prow-job-executor. This adds an optional `allowedSubscriptions` field to the `ProwJob` step; templatize renders it from per-region config and injects it via the Gangway API as `MULTISTAGE_PARAM_OVERRIDE_ALLOWED_SUBSCRIPTIONS`, which the lease-acquire step prefers over the job's baseline allowlist.

## What

- Add optional `AllowedSubscriptions` field to `ProwJobStep` (`pipelines/types/common.go`).
- Add the matching optional `allowedSubscriptions` string property to the prowJob step schema (`pipelines/types/pipeline.schema.v1.json`).

Field is optional and defaults to empty, so existing pipelines are unaffected.