### PR TITLE
Inter service wiring fix

### DIFF
--- a/pipelines/graph/graph.go
+++ b/pipelines/graph/graph.go
@@ -525,14 +525,14 @@ func (c *graphBuilder) wireInterServiceEdges(child *topology.Service, allLeaves 
 	return nil
 }
 
-// findChildRoots returns identifiers of root nodes (no parents) for the child service.
-// Our topology allows each service to depend on one and only one parent, so len(node.Parents) == 0
-// safely identifies root nodes, and this is the only time any actor will add parents to these roots.
+// findChildRoots returns identifiers of root nodes for the child service.
+// A node is a root of its service when it has no intra-service parents.
+// Parents added by inter-service wiring (from other ServiceGroups) do not disqualify it.
 // When both parent and child are stamped, only matching-stamp and unstamped-RG roots are returned.
 func (c *graphBuilder) findChildRoots(child *topology.Service, parentStamp Stamp) sets.Set[Identifier] {
 	roots := sets.New[Identifier]()
 	for _, node := range c.Nodes {
-		if node.ServiceGroup != child.ServiceGroup || len(node.Parents) != 0 {
+		if node.ServiceGroup != child.ServiceGroup || c.hasIntraServiceParent(node) {
 			continue
 		}
 		// Skip child roots whose stamp doesn't match. Unstamped parents or
@@ -543,6 +543,15 @@ func (c *graphBuilder) findChildRoots(child *topology.Service, parentStamp Stamp
 		roots.Insert(node.Identifier)
 	}
 	return roots
+}
+
+func (c *graphBuilder) hasIntraServiceParent(node Node) bool {
+	for _, parent := range node.Parents {
+		if parent.ServiceGroup == node.ServiceGroup {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Graph) lookup(node Identifier) (*topology.Service, *types.ResourceGroupMeta, types.Step, error) {

--- a/pipelines/graph/graph_stamped_test.go
+++ b/pipelines/graph/graph_stamped_test.go
@@ -419,43 +419,41 @@ func TestStampedChildWithMixedRGs(t *testing.T) {
 		},
 	}
 
-	// Build the graph 50 times to defeat Go map iteration non-determinism.
-	// The bug depends on which stamp is wired first in wireInterServiceEdges —
-	// a single build may happen to pick the "right" order and pass.
-	for i := 0; i < 50; i++ {
-		entrypoint := &topo.Entrypoints[0]
-		result, err := ForStampedEntrypoints(topo, []*topology.Entrypoint{entrypoint}, stampPipelines)
-		require.NoError(t, err)
+	entrypoint := &topo.Entrypoints[0]
+	result, err := ForStampedEntrypoints(topo, []*topology.Entrypoint{entrypoint}, stampPipelines)
+	require.NoError(t, err)
 
-		var outputNode Node
-		for _, node := range nodesForSG(result, "SG.ACM") {
-			if node.Step == "output" {
-				outputNode = node
-				break
+	var outputNode Node
+	var foundOutput bool
+	for _, node := range nodesForSG(result, "SG.ACM") {
+		if node.Step == "output" {
+			outputNode = node
+			foundOutput = true
+			break
+		}
+	}
+	require.True(t, foundOutput, "ACM output node must exist in graph")
+	require.False(t, outputNode.Stamp.IsSet(), "output is in unstamped RG")
+
+	var mgmtParentStamps []string
+	for _, parent := range outputNode.Parents {
+		if parent.ServiceGroup == "SG.Mgmt" {
+			mgmtParentStamps = append(mgmtParentStamps, parent.Stamp.String())
+		}
+	}
+	slices.Sort(mgmtParentStamps)
+	require.Equal(t, []string{"1", "2"}, mgmtParentStamps,
+		"unstamped ACM root must depend on both stamps of parent service")
+
+	for _, node := range nodesForSG(result, "SG.Mgmt") {
+		var acmChildren []Identifier
+		for _, child := range node.Children {
+			if child.ServiceGroup == "SG.ACM" {
+				acmChildren = append(acmChildren, child)
 			}
 		}
-		require.False(t, outputNode.Stamp.IsSet(), "output is in unstamped RG")
-
-		var mgmtParentStamps []string
-		for _, parent := range outputNode.Parents {
-			if parent.ServiceGroup == "SG.Mgmt" {
-				mgmtParentStamps = append(mgmtParentStamps, parent.Stamp.String())
-			}
-		}
-		slices.Sort(mgmtParentStamps)
-		require.Equalf(t, []string{"1", "2"}, mgmtParentStamps,
-			"iteration %d: unstamped ACM root must depend on both stamps of parent service", i)
-
-		for _, node := range nodesForSG(result, "SG.Mgmt") {
-			var acmChildren []Identifier
-			for _, child := range node.Children {
-				if child.ServiceGroup == "SG.ACM" {
-					acmChildren = append(acmChildren, child)
-				}
-			}
-			require.NotEmptyf(t, acmChildren,
-				"iteration %d: stamp %s mgmt leaf must have ACM children", i, node.Stamp)
-		}
+		require.NotEmptyf(t, acmChildren,
+			"stamp %s mgmt leaf must have ACM children", node.Stamp)
 	}
 }
 

--- a/pipelines/graph/graph_stamped_test.go
+++ b/pipelines/graph/graph_stamped_test.go
@@ -353,6 +353,112 @@ func TestStampedMixedSiblings(t *testing.T) {
 	}
 }
 
+// TestStampedChildWithMixedRGs tests that when a stamped parent wires to a stamped child
+// whose pipeline has both unstamped and stamped resource groups, the unstamped child roots
+// are wired to ALL parent stamps — not just the first one processed.
+//
+// This reproduces the ACM bug: Management.Infra (stamped) → ACM (stamped, mixed RGs).
+// ACM has unstamped roots (global/output, kusto/lookup) and stamped steps (deploy-mce)
+// that depend on those unstamped roots. Before the fix, map iteration order determined
+// which stamp's leaves got wired to the unstamped roots — the other stamp's leaves
+// were silently dropped.
+//
+//	SG.Regional (unstamped) → SG.Mgmt (stamped, stamped RG only) → SG.ACM (stamped, mixed RGs)
+func TestStampedChildWithMixedRGs(t *testing.T) {
+	deploy := &types.ShellStep{StepMeta: types.StepMeta{Name: "deploy"}}
+
+	topo := makeTopology(topology.Service{
+		ServiceGroup: "SG.Regional", Purpose: "regional", PipelinePath: "regional.yaml",
+		Children: []topology.Service{
+			{ServiceGroup: "SG.Mgmt", Purpose: "mgmt", Stamped: ptr(true), PipelinePath: "mgmt.yaml",
+				Children: []topology.Service{
+					{ServiceGroup: "SG.ACM", Purpose: "acm", PipelinePath: "acm.yaml"},
+				},
+			},
+		},
+	})
+
+	regionalPipeline := makePipeline("SG.Regional", "regional-rg", false, deploy)
+
+	// ACM pipeline: unstamped "global" RG (root) + stamped "mgmt" RG (depends on global)
+	acmPipeline := &types.Pipeline{
+		ServiceGroup: "SG.ACM",
+		ResourceGroups: []*types.ResourceGroup{
+			{
+				ResourceGroupMeta: &types.ResourceGroupMeta{
+					Name: "global", ResourceGroup: "global-rg", Subscription: "sub-global",
+				},
+				Steps: types.Steps{
+					&types.ShellStep{StepMeta: types.StepMeta{Name: "output"}},
+				},
+			},
+			{
+				ResourceGroupMeta: &types.ResourceGroupMeta{
+					Name: "mgmt", ResourceGroup: "mgmt-rg", Subscription: "sub-mgmt", Stamped: true,
+				},
+				Steps: types.Steps{
+					&types.ShellStep{StepMeta: types.StepMeta{
+						Name:      "deploy-mce",
+						DependsOn: []types.StepDependency{{ResourceGroup: "global", Step: "output"}},
+					}},
+				},
+			},
+		},
+	}
+
+	stampPipelines := map[Stamp]map[string]*types.Pipeline{
+		mustStamp("1"): {
+			"SG.Regional": regionalPipeline,
+			"SG.Mgmt":     makePipelineWithRGMeta("SG.Mgmt", &types.ResourceGroupMeta{Name: "mgmt-rg", ResourceGroup: "mgmt-rg-1", Subscription: "sub-1", Stamped: true}, deploy),
+			"SG.ACM":      acmPipeline,
+		},
+		mustStamp("2"): {
+			"SG.Regional": regionalPipeline,
+			"SG.Mgmt":     makePipelineWithRGMeta("SG.Mgmt", &types.ResourceGroupMeta{Name: "mgmt-rg", ResourceGroup: "mgmt-rg-2", Subscription: "sub-2", Stamped: true}, deploy),
+			"SG.ACM":      acmPipeline,
+		},
+	}
+
+	// Build the graph 50 times to defeat Go map iteration non-determinism.
+	// The bug depends on which stamp is wired first in wireInterServiceEdges —
+	// a single build may happen to pick the "right" order and pass.
+	for i := 0; i < 50; i++ {
+		entrypoint := &topo.Entrypoints[0]
+		result, err := ForStampedEntrypoints(topo, []*topology.Entrypoint{entrypoint}, stampPipelines)
+		require.NoError(t, err)
+
+		var outputNode Node
+		for _, node := range nodesForSG(result, "SG.ACM") {
+			if node.Step == "output" {
+				outputNode = node
+				break
+			}
+		}
+		require.False(t, outputNode.Stamp.IsSet(), "output is in unstamped RG")
+
+		var mgmtParentStamps []string
+		for _, parent := range outputNode.Parents {
+			if parent.ServiceGroup == "SG.Mgmt" {
+				mgmtParentStamps = append(mgmtParentStamps, parent.Stamp.String())
+			}
+		}
+		slices.Sort(mgmtParentStamps)
+		require.Equalf(t, []string{"1", "2"}, mgmtParentStamps,
+			"iteration %d: unstamped ACM root must depend on both stamps of parent service", i)
+
+		for _, node := range nodesForSG(result, "SG.Mgmt") {
+			var acmChildren []Identifier
+			for _, child := range node.Children {
+				if child.ServiceGroup == "SG.ACM" {
+					acmChildren = append(acmChildren, child)
+				}
+			}
+			require.NotEmptyf(t, acmChildren,
+				"iteration %d: stamp %s mgmt leaf must have ACM children", i, node.Stamp)
+		}
+	}
+}
+
 // TestStampedNestedChildren tests stamped graph construction with:
 //
 //	SG.Regional (unstamped) → SG.Mgmt (stamped) → SG.MgmtDB (stamped) + SG.MgmtNet (stamped)
@@ -799,7 +905,8 @@ func TestForPipelineStampedService(t *testing.T) {
 //	       ├─ svc-rg (unstamped, shared with Service.Infra, step: lookup)
 //	       ├─ mgmt-rg (stamped, steps: infra → deploy, infra → configure, deploy depends on svc-rg/lookup)
 //	       ├─ Maestro.Agent (stamped, step: deploy, external dep on Service.Infra)
-//	       └─ Fleet.Registration (stamped, RG "svc-rg-stamped" targets same Azure RG as svc-rg, step: register)
+//	       ├─ Fleet.Registration (stamped, RG "svc-rg-stamped" targets same Azure RG as svc-rg, step: register)
+//	       └─ ACM (stamped, mixed RGs: unstamped global/output → stamped mgmt/deploy-mce)
 //
 // Covers:
 //   - unstamped → unstamped topology: Region → Service.Infra
@@ -810,6 +917,8 @@ func TestForPipelineStampedService(t *testing.T) {
 //   - fan-in stamped → unstamped: Management.Infra stamped leaves (deploy + configure) → unstamped child roots
 //   - external dep stamped → unstamped: Maestro.Agent → Service.Infra
 //   - stamped RG targeting same Azure RG: Fleet.Registration "svc" RG → same physical svc-rg, per-stamp colored
+//   - stamped child with mixed RGs: ACM has unstamped root (global/output) + stamped steps (deploy-mce);
+//     both stamp leaves of Management.Infra must wire to the single unstamped ACM root
 func TestStampedEntrypointDOT(t *testing.T) {
 	deploy := &types.ShellStep{StepMeta: types.StepMeta{Name: "deploy"}}
 
@@ -833,6 +942,11 @@ func TestStampedEntrypointDOT(t *testing.T) {
 
 	fleetRegister := &types.ShellStep{StepMeta: types.StepMeta{Name: "register"}}
 
+	acmDeployMCE := &types.ShellStep{StepMeta: types.StepMeta{
+		Name:      "deploy-mce",
+		DependsOn: []types.StepDependency{{ResourceGroup: "acm-global", Step: "output"}},
+	}}
+
 	topo := makeTopology(topology.Service{
 		ServiceGroup: "Microsoft.Azure.ARO.HCP.Region", Purpose: "region", PipelinePath: "region.yaml",
 		Children: []topology.Service{
@@ -841,6 +955,7 @@ func TestStampedEntrypointDOT(t *testing.T) {
 				Children: []topology.Service{
 					{ServiceGroup: "Microsoft.Azure.ARO.HCP.Maestro.Agent", Purpose: "maestro agent", PipelinePath: "maestro-agent.yaml"},
 					{ServiceGroup: "Microsoft.Azure.ARO.HCP.Fleet.Registration", Purpose: "fleet registration", PipelinePath: "fleet-reg.yaml"},
+					{ServiceGroup: "Microsoft.Azure.ARO.HCP.ACM", Purpose: "acm", PipelinePath: "acm.yaml"},
 				},
 			},
 		},
@@ -848,6 +963,26 @@ func TestStampedEntrypointDOT(t *testing.T) {
 
 	regionPipeline := makePipeline("Microsoft.Azure.ARO.HCP.Region", "region-rg", false, deploy)
 	svcPipeline := makePipeline("Microsoft.Azure.ARO.HCP.Service.Infra", "svc-rg", false, deploy)
+
+	acmPipeline := &types.Pipeline{
+		ServiceGroup: "Microsoft.Azure.ARO.HCP.ACM",
+		ResourceGroups: []*types.ResourceGroup{
+			{
+				ResourceGroupMeta: &types.ResourceGroupMeta{
+					Name: "acm-global", ResourceGroup: "acm-global-rg", Subscription: "sub-acm-global",
+				},
+				Steps: types.Steps{
+					&types.ShellStep{StepMeta: types.StepMeta{Name: "output"}},
+				},
+			},
+			{
+				ResourceGroupMeta: &types.ResourceGroupMeta{
+					Name: "acm-mgmt", ResourceGroup: "acm-mgmt-rg", Subscription: "sub-acm-mgmt", Stamped: true,
+				},
+				Steps: types.Steps{acmDeployMCE},
+			},
+		},
+	}
 
 	mgmtPipeline := func(rgName, sub string) *types.Pipeline {
 		return &types.Pipeline{
@@ -876,6 +1011,7 @@ func TestStampedEntrypointDOT(t *testing.T) {
 			"Microsoft.Azure.ARO.HCP.Management.Infra":   mgmtPipeline("mgmt-rg-1", "sub-1"),
 			"Microsoft.Azure.ARO.HCP.Maestro.Agent":      makePipeline("Microsoft.Azure.ARO.HCP.Maestro.Agent", "maestro-rg", true, maestroDeploy),
 			"Microsoft.Azure.ARO.HCP.Fleet.Registration": makePipelineWithRGMeta("Microsoft.Azure.ARO.HCP.Fleet.Registration", &types.ResourceGroupMeta{Name: "svc-rg-stamped", ResourceGroup: "svc-rg", Subscription: "sub-svc-rg", Stamped: true}, fleetRegister),
+			"Microsoft.Azure.ARO.HCP.ACM":                acmPipeline,
 		},
 		mustStamp("2"): {
 			"Microsoft.Azure.ARO.HCP.Region":             regionPipeline,
@@ -883,6 +1019,7 @@ func TestStampedEntrypointDOT(t *testing.T) {
 			"Microsoft.Azure.ARO.HCP.Management.Infra":   mgmtPipeline("mgmt-rg-2", "sub-2"),
 			"Microsoft.Azure.ARO.HCP.Maestro.Agent":      makePipeline("Microsoft.Azure.ARO.HCP.Maestro.Agent", "maestro-rg", true, maestroDeploy),
 			"Microsoft.Azure.ARO.HCP.Fleet.Registration": makePipelineWithRGMeta("Microsoft.Azure.ARO.HCP.Fleet.Registration", &types.ResourceGroupMeta{Name: "svc-rg-stamped", ResourceGroup: "svc-rg", Subscription: "sub-svc-rg", Stamped: true}, fleetRegister),
+			"Microsoft.Azure.ARO.HCP.ACM":                acmPipeline,
 		},
 	}
 

--- a/pipelines/graph/testdata/zz_fixture_TestStampedEntrypointDOT.dot
+++ b/pipelines/graph/testdata/zz_fixture_TestStampedEntrypointDOT.dot
@@ -27,9 +27,11 @@ digraph regexp {
  "Management.Infra_mgmt-rg_configure_2" [label="Management.Infra/mgmt-rg-2/configure (stamp=2)" style=filled fillcolor="#FFD9B3"];
  "Management.Infra_mgmt-rg_configure_2" -> "Maestro.Agent_maestro-rg_deploy_2";
  "Management.Infra_mgmt-rg_configure_2" -> "Fleet.Registration_svc-rg-stamped_register_2";
+ "Management.Infra_mgmt-rg_configure_2" -> "ACM_acm-global_output";
  "Management.Infra_mgmt-rg_deploy_2" [label="Management.Infra/mgmt-rg-2/deploy (stamp=2)" style=filled fillcolor="#FFD9B3"];
  "Management.Infra_mgmt-rg_deploy_2" -> "Maestro.Agent_maestro-rg_deploy_2";
  "Management.Infra_mgmt-rg_deploy_2" -> "Fleet.Registration_svc-rg-stamped_register_2";
+ "Management.Infra_mgmt-rg_deploy_2" -> "ACM_acm-global_output";
  "Management.Infra_mgmt-rg_infra_2" [label="Management.Infra/mgmt-rg-2/infra (stamp=2)" style=filled fillcolor="#FFD9B3"];
  "Management.Infra_mgmt-rg_infra_2" -> "Management.Infra_mgmt-rg_configure_2";
  "Management.Infra_mgmt-rg_infra_2" -> "Management.Infra_mgmt-rg_deploy_2";

--- a/pipelines/graph/testdata/zz_fixture_TestStampedEntrypointDOT.dot
+++ b/pipelines/graph/testdata/zz_fixture_TestStampedEntrypointDOT.dot
@@ -16,9 +16,11 @@ digraph regexp {
  "Management.Infra_mgmt-rg_configure_1" [label="Management.Infra/mgmt-rg-1/configure (stamp=1)" style=filled fillcolor="#B3D9FF"];
  "Management.Infra_mgmt-rg_configure_1" -> "Maestro.Agent_maestro-rg_deploy_1";
  "Management.Infra_mgmt-rg_configure_1" -> "Fleet.Registration_svc-rg-stamped_register_1";
+ "Management.Infra_mgmt-rg_configure_1" -> "ACM_acm-global_output";
  "Management.Infra_mgmt-rg_deploy_1" [label="Management.Infra/mgmt-rg-1/deploy (stamp=1)" style=filled fillcolor="#B3D9FF"];
  "Management.Infra_mgmt-rg_deploy_1" -> "Maestro.Agent_maestro-rg_deploy_1";
  "Management.Infra_mgmt-rg_deploy_1" -> "Fleet.Registration_svc-rg-stamped_register_1";
+ "Management.Infra_mgmt-rg_deploy_1" -> "ACM_acm-global_output";
  "Management.Infra_mgmt-rg_infra_1" [label="Management.Infra/mgmt-rg-1/infra (stamp=1)" style=filled fillcolor="#B3D9FF"];
  "Management.Infra_mgmt-rg_infra_1" -> "Management.Infra_mgmt-rg_configure_1";
  "Management.Infra_mgmt-rg_infra_1" -> "Management.Infra_mgmt-rg_deploy_1";
@@ -35,4 +37,9 @@ digraph regexp {
  "Maestro.Agent_maestro-rg_deploy_2" [label="Maestro.Agent/maestro-rg/deploy (stamp=2)" style=filled fillcolor="#FFD9B3"];
  "Fleet.Registration_svc-rg-stamped_register_1" [label="Fleet.Registration/svc-rg/register (stamp=1)" style=filled fillcolor="#B3D9FF"];
  "Fleet.Registration_svc-rg-stamped_register_2" [label="Fleet.Registration/svc-rg/register (stamp=2)" style=filled fillcolor="#FFD9B3"];
+ "ACM_acm-global_output" [label="ACM/acm-global-rg/output"];
+ "ACM_acm-global_output" -> "ACM_acm-mgmt_deploy-mce_1";
+ "ACM_acm-global_output" -> "ACM_acm-mgmt_deploy-mce_2";
+ "ACM_acm-mgmt_deploy-mce_1" [label="ACM/acm-mgmt-rg/deploy-mce (stamp=1)" style=filled fillcolor="#B3D9FF"];
+ "ACM_acm-mgmt_deploy-mce_2" [label="ACM/acm-mgmt-rg/deploy-mce (stamp=2)" style=filled fillcolor="#FFD9B3"];
 }


### PR DESCRIPTION
findChildRoots used len(node.Parents) == 0 as a proxy for "root of
service". When wireInterServiceEdges iterated multiple parent stamps,
the first stamp to wire added Parents to unstamped child roots,
causing subsequent stamps to skip them — their leaves wired to
nothing.

Replace with hasIntraServiceParent, which checks for parents within
the same ServiceGroup. Inter-service parents added by wiring do not
disqualify a node as a root of its own service. This makes root
detection order-independent by construction.

Manifested as: ACM deploy-mce on stamp 2 ran before prometheus
installed ServiceMonitor CRDs, because stamp 2's management cluster
leaves were never wired as dependencies of ACM's unstamped roots.

the fix can be seen in action in the change to pipelines/graph/testdata/zz_fixture_TestStampedEntrypointDOT.dot in the second commit 