### PR TITLE
fix(grafanactl): preserve dashboard JSON fields

### DIFF
--- a/tools/grafanactl/go.mod
+++ b/tools/grafanactl/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/yaml v1.6.0
@@ -23,6 +24,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/gobwas/ws v1.2.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -42,4 +45,5 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/grafanactl/internal/grafana/client.go
+++ b/tools/grafanactl/internal/grafana/client.go
@@ -149,14 +149,27 @@ func (c *Client) GetDashboardByUID(ctx context.Context, uid string) (sdk.Board, 
 	return board, props, nil
 }
 
-// SetDashboard creates or updates a dashboard.
-func (c *Client) SetDashboard(ctx context.Context, board sdk.Board, folderID int, overwrite bool) error {
-	params := sdk.SetDashboardParams{
-		FolderID:  folderID,
-		Overwrite: overwrite,
+// GetRawDashboardByUID retrieves a dashboard by its UID without discarding fields unknown to the SDK.
+func (c *Client) GetRawDashboardByUID(ctx context.Context, uid string) ([]byte, sdk.BoardProperties, error) {
+	board, props, err := c.grafanaClient.GetRawDashboardByUID(ctx, uid)
+	if err != nil {
+		return nil, sdk.BoardProperties{}, fmt.Errorf("failed to get dashboard %q: %w", uid, err)
 	}
 
-	_, err := c.grafanaClient.SetDashboard(ctx, board, params)
+	return board, props, nil
+}
+
+// SetRawDashboard creates or updates a dashboard without discarding fields unknown to the SDK.
+func (c *Client) SetRawDashboard(ctx context.Context, dashboard []byte, folderID int, overwrite bool) error {
+	request := sdk.RawBoardRequest{
+		Dashboard: dashboard,
+		Parameters: sdk.SetDashboardParams{
+			FolderID:  folderID,
+			Overwrite: overwrite,
+		},
+	}
+
+	_, err := c.grafanaClient.SetRawDashboardWithParam(ctx, request)
 	if err != nil {
 		return fmt.Errorf("failed to set dashboard: %w", err)
 	}

--- a/tools/grafanactl/internal/grafana/client_test.go
+++ b/tools/grafanactl/internal/grafana/client_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grafana
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana-tools/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetRawDashboardPreservesUnknownFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/api/dashboards/db", request.URL.Path)
+
+		var payload struct {
+			Dashboard map[string]interface{} `json:"dashboard"`
+			FolderID  int                    `json:"folderId"`
+			Overwrite bool                   `json:"overwrite"`
+		}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&payload))
+		require.Equal(t, 12, payload.FolderID)
+		require.True(t, payload.Overwrite)
+
+		dashboard := payload.Dashboard
+		require.Equal(t, float64(0), dashboard["id"])
+		panel := dashboard["panels"].([]interface{})[0].(map[string]interface{})
+		require.Contains(t, panel, "transformations")
+		require.Contains(t, panel, "pluginSpecificField")
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := writer.Write([]byte(`{"status":"success","uid":"test-dashboard"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	sdkClient, err := sdk.NewClient(server.URL, "", server.Client())
+	require.NoError(t, err)
+	client := &Client{grafanaClient: sdkClient}
+
+	require.NoError(t, client.SetRawDashboard(context.Background(), []byte(dashboardJSON), 12, true))
+}
+
+func TestGetRawDashboardPreservesUnknownFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/api/dashboards/uid/test-dashboard", request.URL.Path)
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := writer.Write([]byte(`{"dashboard":` + dashboardJSON + `,"meta":{"folderId":12}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	sdkClient, err := sdk.NewClient(server.URL, "", server.Client())
+	require.NoError(t, err)
+	client := &Client{grafanaClient: sdkClient}
+
+	raw, properties, err := client.GetRawDashboardByUID(context.Background(), "test-dashboard")
+	require.NoError(t, err)
+	require.Equal(t, 12, properties.FolderID)
+
+	var dashboard map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &dashboard))
+	panel := dashboard["panels"].([]interface{})[0].(map[string]interface{})
+	require.Contains(t, panel, "transformations")
+	require.Contains(t, panel, "pluginSpecificField")
+}

--- a/tools/grafanactl/internal/grafana/syncer.go
+++ b/tools/grafanactl/internal/grafana/syncer.go
@@ -15,9 +15,11 @@
 package grafana
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +45,11 @@ type ValidationIssue struct {
 	Folder  string
 	Title   string
 	Message string
+}
+
+type dashboardDocument struct {
+	raw   json.RawMessage
+	board sdk.Board
 }
 
 // fetchExistingState fetches existing folders and dashboards from Grafana.
@@ -135,7 +142,7 @@ func (s *DashboardSyncer) syncFolder(ctx context.Context, folder config.Dashboar
 	for _, dashboard := range dashboards {
 		errors, warnings, err := s.syncDashboard(ctx, dashboard, grafanaFolder, folder.Path, existingDashboards, dashboardsVisited)
 		if err != nil {
-			logger.Error(err, "Failed to sync dashboard", "title", dashboard.Title)
+			logger.Error(err, "Failed to sync dashboard", "title", dashboard.board.Title)
 		}
 		validationErrors = append(validationErrors, errors...)
 		validationWarnings = append(validationWarnings, warnings...)
@@ -169,7 +176,7 @@ func (s *DashboardSyncer) getOrCreateFolder(ctx context.Context, name string, ex
 	return folder, nil
 }
 
-func (s *DashboardSyncer) readDashboardsFromPath(ctx context.Context, path string) ([]sdk.Board, error) {
+func (s *DashboardSyncer) readDashboardsFromPath(ctx context.Context, path string) ([]dashboardDocument, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	fullPath := filepath.Join(s.configDir, path)
 	logger.V(1).Info("Reading dashboards", "path", fullPath)
@@ -179,7 +186,7 @@ func (s *DashboardSyncer) readDashboardsFromPath(ctx context.Context, path strin
 		return nil, fmt.Errorf("failed to read directory: %w", err)
 	}
 
-	var dashboards []sdk.Board
+	var dashboards []dashboardDocument
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
@@ -198,53 +205,65 @@ func (s *DashboardSyncer) readDashboardsFromPath(ctx context.Context, path strin
 	return dashboards, nil
 }
 
-func readDashboardFile(path string) (sdk.Board, error) {
+func readDashboardFile(path string) (dashboardDocument, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return sdk.Board{}, fmt.Errorf("failed to read file %q: %w", path, err)
+		return dashboardDocument{}, fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	// Try parsing as wrapped format {"dashboard": {...}}
 	var wrapped struct {
-		Dashboard sdk.Board `json:"dashboard"`
+		Dashboard json.RawMessage `json:"dashboard"`
 	}
-	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Dashboard.Title != "" {
-		return wrapped.Dashboard, nil
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.Dashboard) > 0 {
+		dashboard, err := parseDashboard(wrapped.Dashboard)
+		if err != nil {
+			return dashboardDocument{}, fmt.Errorf("failed to parse wrapped dashboard JSON: %w", err)
+		}
+		if dashboard.board.Title != "" {
+			return dashboard, nil
+		}
 	}
 
-	// Try parsing as raw dashboard
-	var board sdk.Board
-	if err := json.Unmarshal(data, &board); err != nil {
-		return sdk.Board{}, fmt.Errorf("failed to parse dashboard JSON: %w", err)
-	}
-
-	return board, nil
+	return parseDashboard(data)
 }
 
-func (s *DashboardSyncer) syncDashboard(ctx context.Context, localDashboard sdk.Board, folder sdk.Folder, folderPath string, existingDashboards []sdk.FoundBoard, dashboardsVisited map[string]bool) ([]ValidationIssue, []ValidationIssue, error) {
+func parseDashboard(data []byte) (dashboardDocument, error) {
+	var board sdk.Board
+	if err := json.Unmarshal(data, &board); err != nil {
+		return dashboardDocument{}, fmt.Errorf("failed to parse dashboard JSON: %w", err)
+	}
+
+	return dashboardDocument{
+		raw:   append(json.RawMessage(nil), data...),
+		board: board,
+	}, nil
+}
+
+func (s *DashboardSyncer) syncDashboard(ctx context.Context, localDashboard dashboardDocument, folder sdk.Folder, folderPath string, existingDashboards []sdk.FoundBoard, dashboardsVisited map[string]bool) ([]ValidationIssue, []ValidationIssue, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	errors, warnings := validateDashboard(localDashboard, folderPath)
+	errors, warnings := validateDashboard(localDashboard.board, folderPath)
 
 	if len(errors) > 0 {
-		logger.Info("Skipping dashboard due to validation errors", "title", localDashboard.Title)
+		logger.Info("Skipping dashboard due to validation errors", "title", localDashboard.board.Title)
 		return errors, warnings, nil
 	}
 
 	// Mark dashboard UID as visited
-	dashboardsVisited[localDashboard.UID] = true
+	dashboardsVisited[localDashboard.board.UID] = true
 
 	// Check if dashboard already exists in Grafana
-	existingBoard := findExistingDashboard(localDashboard.UID, existingDashboards)
+	existingBoard := findExistingDashboard(localDashboard.board.UID, existingDashboards)
 
 	// If dashboard exists in the correct folder, check if it matches
 	if existingBoard != nil && existingBoard.FolderUID == folder.UID {
-		remoteDashboard, _, err := s.client.GetDashboardByUID(ctx, localDashboard.UID)
+		remoteDashboard, _, err := s.client.GetRawDashboardByUID(ctx, localDashboard.board.UID)
 		if err != nil {
-			return errors, warnings, fmt.Errorf("failed to fetch remote dashboard %q: %w", localDashboard.Title, err)
+			return errors, warnings, fmt.Errorf("failed to fetch remote dashboard %q: %w", localDashboard.board.Title, err)
 		}
-		if areDashboardsEqual(remoteDashboard, localDashboard) {
-			logger.V(1).Info("Dashboard matches, no update needed", "title", localDashboard.Title)
+		if areDashboardsEqual(remoteDashboard, localDashboard.raw) {
+			logger.V(1).Info("Dashboard matches, no update needed", "title", localDashboard.board.Title)
 			return errors, warnings, nil
 		}
 	}
@@ -254,17 +273,19 @@ func (s *DashboardSyncer) syncDashboard(ctx context.Context, localDashboard sdk.
 	if existingBoard != nil {
 		action = "Updating"
 	}
-	logger.Info(action+" dashboard", "title", localDashboard.Title, "folder", folder.Title)
+	logger.Info(action+" dashboard", "title", localDashboard.board.Title, "folder", folder.Title)
 
 	if s.dryRun {
-		logger.Info("DRY_RUN: Would "+strings.ToLower(action)+" dashboard", "title", localDashboard.Title, "folder", folder.Title)
+		logger.Info("DRY_RUN: Would "+strings.ToLower(action)+" dashboard", "title", localDashboard.board.Title, "folder", folder.Title)
 		return errors, warnings, nil
 	}
 
-	// Clear ID and Version so Grafana uses UID for lookup (values in JSON files may be stale)
-	localDashboard.ID = 0
-	localDashboard.Version = 0
-	return errors, warnings, s.client.SetDashboard(ctx, localDashboard, folder.ID, true)
+	dashboardToUpload, err := normalizeDashboard(localDashboard.raw)
+	if err != nil {
+		return errors, warnings, fmt.Errorf("failed to prepare dashboard %q for upload: %w", localDashboard.board.Title, err)
+	}
+
+	return errors, warnings, s.client.SetRawDashboard(ctx, dashboardToUpload, folder.ID, true)
 }
 
 func findExistingDashboard(uid string, existingDashboards []sdk.FoundBoard) *sdk.FoundBoard {
@@ -276,25 +297,41 @@ func findExistingDashboard(uid string, existingDashboards []sdk.FoundBoard) *sdk
 	return nil
 }
 
-func areDashboardsEqual(remote, local sdk.Board) bool {
-	// Clear fields that change on save
-	remote.ID = 0
-	local.ID = 0
-	remote.Version = 0
-	local.Version = 0
-
-	// Compare JSON representations to avoid type mismatches
-	// (e.g., string "1" vs float64 1 in interface{} fields)
-	remoteJSON, err := json.Marshal(remote)
+func areDashboardsEqual(remote, local []byte) bool {
+	remoteJSON, err := normalizeDashboard(remote)
 	if err != nil {
 		return false
 	}
-	localJSON, err := json.Marshal(local)
+	localJSON, err := normalizeDashboard(local)
 	if err != nil {
 		return false
 	}
 
-	return string(remoteJSON) == string(localJSON)
+	return bytes.Equal(remoteJSON, localJSON)
+}
+
+func normalizeDashboard(raw []byte) ([]byte, error) {
+	var dashboard map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&dashboard); err != nil {
+		return nil, err
+	}
+	if dashboard == nil {
+		return nil, fmt.Errorf("dashboard is not a JSON object")
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("dashboard contains multiple JSON values")
+		}
+		return nil, fmt.Errorf("dashboard contains trailing data: %w", err)
+	}
+
+	dashboard["id"] = json.Number("0")
+	dashboard["version"] = json.Number("0")
+
+	return json.Marshal(dashboard)
 }
 
 // validateDashboard validates a dashboard and returns validation errors and warnings.

--- a/tools/grafanactl/internal/grafana/syncer_test.go
+++ b/tools/grafanactl/internal/grafana/syncer_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grafana
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const dashboardJSON = `{
+  "id": null,
+  "uid": "test-dashboard",
+  "title": "Test Dashboard",
+  "version": 7,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "query": "prometheus",
+        "regex": "/managed-prometheus/",
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Status",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "^Value$",
+            "renamePattern": "Time in Progress (Minutes)"
+          }
+        }
+      ],
+      "pluginSpecificField": {
+        "preserve": true
+      }
+    }
+  ]
+}`
+
+func TestReadDashboardFilePreservesUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dashboard.json")
+	require.NoError(t, os.WriteFile(path, []byte(dashboardJSON), 0o600))
+
+	dashboard, err := readDashboardFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "test-dashboard", dashboard.board.UID)
+	require.Equal(t, "Test Dashboard", dashboard.board.Title)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(dashboard.raw, &raw))
+	panel := raw["panels"].([]interface{})[0].(map[string]interface{})
+	require.Contains(t, panel, "transformations")
+	require.Contains(t, panel, "pluginSpecificField")
+}
+
+func TestReadDashboardFileUnwrapsDashboard(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dashboard.json")
+	wrapped := `{"dashboard":` + dashboardJSON + `,"meta":{"folderId":12}}`
+	require.NoError(t, os.WriteFile(path, []byte(wrapped), 0o600))
+
+	dashboard, err := readDashboardFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "test-dashboard", dashboard.board.UID)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(dashboard.raw, &raw))
+	require.NotContains(t, raw, "dashboard")
+	require.Contains(t, raw, "panels")
+}
+
+func TestReadDashboardFileReturnsWrappedParseError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dashboard.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"dashboard":"invalid"}`), 0o600))
+
+	_, err := readDashboardFile(path)
+	require.ErrorContains(t, err, "failed to parse wrapped dashboard JSON")
+}
+
+func TestReadDashboardFileFallsBackForRawDashboardField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dashboard.json")
+	raw := `{"dashboard":{},"uid":"test-dashboard","title":"Test Dashboard"}`
+	require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+
+	dashboard, err := readDashboardFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "test-dashboard", dashboard.board.UID)
+	require.JSONEq(t, raw, string(dashboard.raw))
+}
+
+func TestAreDashboardsEqual(t *testing.T) {
+	remote := []byte(dashboardJSON)
+	local := []byte(dashboardJSON)
+	require.True(t, areDashboardsEqual(remote, local))
+	require.False(t, areDashboardsEqual([]byte("null"), local))
+
+	var changedID map[string]interface{}
+	require.NoError(t, json.Unmarshal(remote, &changedID))
+	changedID["id"] = 42
+	changedID["version"] = 99
+	remote, err := json.Marshal(changedID)
+	require.NoError(t, err)
+	require.True(t, areDashboardsEqual(remote, local))
+
+	var changedTransformation map[string]interface{}
+	require.NoError(t, json.Unmarshal(local, &changedTransformation))
+	panel := changedTransformation["panels"].([]interface{})[0].(map[string]interface{})
+	transform := panel["transformations"].([]interface{})[0].(map[string]interface{})
+	transform["id"] = "organize"
+	local, err = json.Marshal(changedTransformation)
+	require.NoError(t, err)
+	require.False(t, areDashboardsEqual(remote, local))
+}
+
+func TestNormalizeDashboardClearsGrafanaManagedFields(t *testing.T) {
+	normalized, err := normalizeDashboard([]byte(dashboardJSON))
+	require.NoError(t, err)
+
+	var dashboard map[string]interface{}
+	require.NoError(t, json.Unmarshal(normalized, &dashboard))
+	require.Equal(t, float64(0), dashboard["id"])
+	require.Equal(t, float64(0), dashboard["version"])
+
+	panel := dashboard["panels"].([]interface{})[0].(map[string]interface{})
+	require.Contains(t, panel, "transformations")
+	require.Contains(t, panel, "pluginSpecificField")
+}
+
+func TestNormalizeDashboardRejectsTrailingData(t *testing.T) {
+	_, err := normalizeDashboard([]byte(dashboardJSON + ` garbage`))
+	require.ErrorContains(t, err, "dashboard contains trailing data")
+
+	_, err = normalizeDashboard([]byte(dashboardJSON + ` {}`))
+	require.ErrorContains(t, err, "dashboard contains multiple JSON values")
+}

--- a/tools/grafanactl/internal/grafana/validator.go
+++ b/tools/grafanactl/internal/grafana/validator.go
@@ -52,7 +52,7 @@ func ValidateAllDashboards(ctx context.Context, cfg *config.ObservabilityConfig,
 				continue
 			}
 
-			errors, warnings := validateDashboard(dashboard, folder.Path)
+			errors, warnings := validateDashboard(dashboard.board, folder.Path)
 			allErrors = append(allErrors, errors...)
 			allWarnings = append(allWarnings, warnings...)
 		}


### PR DESCRIPTION
[ARO-28835](https://redhat.atlassian.net/browse/ARO-28835)

## Summary

`grafanactl` currently parses dashboard JSON into the Grafana Go SDK's typed dashboard model before comparison and upload. That model does not include transformations or many plugin-specific fields, so those fields are silently removed during synchronization.

No newer SDK version provides a complete dashboard model. This change preserves the original dashboard JSON for comparison and upload while continuing to use the typed model for existing metadata validation. It normalizes only Grafana-managed fields such as `id` and `version`, preserving transformations and unknown plugin fields without changing existing folder, dry-run, or stale-dashboard behavior.

The detailed problem statement and acceptance criteria are tracked in [ARO-28835](https://redhat.atlassian.net/browse/ARO-28835).

## Testing

- `go test ./...`
- `go test -race ./...`
- `go tool golangci-lint run ./...`
