### PR TITLE
feat(prow-job-executor): read the retry signal from finished.json metadata (AROSLSRE-1721)

### DIFF
--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -84,6 +84,7 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&o.ProwURL, "prow-url", o.ProwURL, "Prow API URL for job status monitoring")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print which job would be started, but do not start one.")
 	cmd.Flags().BoolVar(&o.GatePromotion, "gate-promotion", o.GatePromotion, "Exit with an error code if the job fails.")
+	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, resubmit it once if its build log carries the EV2_RETRY_ALLOWED marker (AROSLSRE-1721).")
 	cmd.Flags().StringVar(&o.BaseSha, "base-sha", o.BaseSha, "Git commit SHA to test against. When set, the job is triggered as a postsubmit with this specific commit instead of HEAD.")
 	cmd.Flags().StringVar(&o.BaseRef, "base-ref", o.BaseRef, "Git base ref (branch) for the postsubmit job (requires --base-sha)")
 	cmd.Flags().StringVar(&o.Org, "org", o.Org, "GitHub org for the postsubmit job (requires --base-sha)")
@@ -123,6 +124,7 @@ type RawExecuteOptions struct {
 	ProwURL              string
 	DryRun               bool
 	GatePromotion        bool
+	AllowEV2Retry        bool
 
 	// Git ref options for postsubmit execution pinned to a specific commit.
 	// When BaseSha is set, the job is triggered as a postsubmit instead of a periodic.
@@ -163,6 +165,7 @@ type completedExecuteOptions struct {
 	ProwURL              string
 	DryRun               bool
 	GatePromotion        bool
+	AllowEV2Retry        bool
 
 	// Git ref options for postsubmit execution
 	BaseSha string
@@ -295,6 +298,7 @@ func (o *ValidatedExecuteOptions) Complete(ctx context.Context) (*ExecuteOptions
 			ProwURL:              o.ProwURL,
 			DryRun:               o.DryRun,
 			GatePromotion:        o.GatePromotion,
+			AllowEV2Retry:        o.AllowEV2Retry,
 			BaseSha:              o.BaseSha,
 			BaseRef:              o.BaseRef,
 			Org:                  o.Org,
@@ -313,7 +317,7 @@ func (o *ExecuteOptions) Execute(ctx context.Context) error {
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
 
 	// Create job monitor
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion, o.AllowEV2Retry)
 
 	// Prepare environment variables, including the region
 	envs := make(map[string]string)
@@ -516,7 +520,7 @@ func (o *ValidatedMonitorOptions) Complete(ctx context.Context) (*MonitorOptions
 func (o *MonitorOptions) Monitor(ctx context.Context, logger logr.Logger) error {
 	// Create Prow client and monitor
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false, false)
 
 	// Monitor existing job using shared polling logic
 	logger.Info("Starting to monitor existing job", "jobExecutionID", o.JobExecutionID)

--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -85,7 +85,7 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&o.ProwURL, "prow-url", o.ProwURL, "Prow API URL for job status monitoring")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print which job would be started, but do not start one.")
 	cmd.Flags().BoolVar(&o.GatePromotion, "gate-promotion", o.GatePromotion, "Exit with an error code if the job fails.")
-	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, resubmit it once if its finished.json metadata marks the failure as narrow enough to safely retry (AROSLSRE-1721).")
+	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, fail with a distinct, matchable error if its finished.json metadata marks the failure as narrow enough to safely retry, so the gating step's EV2 automatedRetry re-runs the whole step (AROSLSRE-1721). Does not resubmit the job itself.")
 	cmd.Flags().IntVar(&o.MaxEV2AutoRetryFailures, "max-ev2-auto-retry-failures", o.MaxEV2AutoRetryFailures, "Maximum number of failed tests (all labeled allow-retry) a job may have and still qualify for an automatic EV2 gating retry. Has no effect unless allow-ev2-retry is set.")
 	cmd.Flags().StringVar(&o.BaseSha, "base-sha", o.BaseSha, "Git commit SHA to test against. When set, the job is triggered as a postsubmit with this specific commit instead of HEAD.")
 	cmd.Flags().StringVar(&o.BaseRef, "base-ref", o.BaseRef, "Git base ref (branch) for the postsubmit job (requires --base-sha)")

--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -54,17 +54,18 @@ const (
 
 func DefaultExecuteOptions() *RawExecuteOptions {
 	return &RawExecuteOptions{
-		RawProwTokenOptions: NewDefaultRawProwTokenOptions(),
-		Labels:              make(map[string]string),
-		Annotations:         make(map[string]string),
-		EnvironmentVars:     make(map[string]string),
-		PollInterval:        300 * time.Second,
-		Timeout:             4 * time.Hour,
-		GangwayURL:          defaultGangwayURL,
-		ProwURL:             defaultProwURL,
-		BaseRef:             defaultBaseRef,
-		Org:                 defaultOrg,
-		Repo:                defaultRepo,
+		RawProwTokenOptions:     NewDefaultRawProwTokenOptions(),
+		Labels:                  make(map[string]string),
+		Annotations:             make(map[string]string),
+		EnvironmentVars:         make(map[string]string),
+		PollInterval:            300 * time.Second,
+		Timeout:                 4 * time.Hour,
+		GangwayURL:              defaultGangwayURL,
+		ProwURL:                 defaultProwURL,
+		BaseRef:                 defaultBaseRef,
+		Org:                     defaultOrg,
+		Repo:                    defaultRepo,
+		MaxEV2AutoRetryFailures: prowjob.DefaultMaxEV2AutoRetryFailures,
 	}
 }
 
@@ -84,7 +85,8 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&o.ProwURL, "prow-url", o.ProwURL, "Prow API URL for job status monitoring")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print which job would be started, but do not start one.")
 	cmd.Flags().BoolVar(&o.GatePromotion, "gate-promotion", o.GatePromotion, "Exit with an error code if the job fails.")
-	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, resubmit it once if its build log carries the EV2_RETRY_ALLOWED marker (AROSLSRE-1721).")
+	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, resubmit it once if its finished.json metadata marks the failure as narrow enough to safely retry (AROSLSRE-1721).")
+	cmd.Flags().IntVar(&o.MaxEV2AutoRetryFailures, "max-ev2-auto-retry-failures", o.MaxEV2AutoRetryFailures, "Maximum number of failed tests (all labeled allow-retry) a job may have and still qualify for an automatic EV2 gating retry. Has no effect unless allow-ev2-retry is set.")
 	cmd.Flags().StringVar(&o.BaseSha, "base-sha", o.BaseSha, "Git commit SHA to test against. When set, the job is triggered as a postsubmit with this specific commit instead of HEAD.")
 	cmd.Flags().StringVar(&o.BaseRef, "base-ref", o.BaseRef, "Git base ref (branch) for the postsubmit job (requires --base-sha)")
 	cmd.Flags().StringVar(&o.Org, "org", o.Org, "GitHub org for the postsubmit job (requires --base-sha)")
@@ -109,22 +111,23 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 type RawExecuteOptions struct {
 	*RawProwTokenOptions
 
-	Cloud                string
-	Environment          string
-	Region               string
-	AllowedSubscriptions string
-	ProwJobName          string
-	Labels               map[string]string
-	Annotations          map[string]string
-	EnvironmentVars      map[string]string
-	EV2RolloutVersion    string
-	PollInterval         time.Duration
-	Timeout              time.Duration
-	GangwayURL           string
-	ProwURL              string
-	DryRun               bool
-	GatePromotion        bool
-	AllowEV2Retry        bool
+	Cloud                   string
+	Environment             string
+	Region                  string
+	AllowedSubscriptions    string
+	ProwJobName             string
+	Labels                  map[string]string
+	Annotations             map[string]string
+	EnvironmentVars         map[string]string
+	EV2RolloutVersion       string
+	PollInterval            time.Duration
+	Timeout                 time.Duration
+	GangwayURL              string
+	ProwURL                 string
+	DryRun                  bool
+	GatePromotion           bool
+	AllowEV2Retry           bool
+	MaxEV2AutoRetryFailures int
 
 	// Git ref options for postsubmit execution pinned to a specific commit.
 	// When BaseSha is set, the job is triggered as a postsubmit instead of a periodic.
@@ -150,22 +153,23 @@ type ValidatedExecuteOptions struct {
 
 // completedExecuteOptions is a private wrapper that enforces a call of Complete() before execution can be invoked.
 type completedExecuteOptions struct {
-	Cloud                string
-	Environment          string
-	Region               string
-	AllowedSubscriptions string
-	ProwJobName          string
-	Labels               map[string]string
-	Annotations          map[string]string
-	EnvironmentVars      map[string]string
-	PollInterval         time.Duration
-	Timeout              time.Duration
-	ProwToken            string
-	GangwayURL           string
-	ProwURL              string
-	DryRun               bool
-	GatePromotion        bool
-	AllowEV2Retry        bool
+	Cloud                   string
+	Environment             string
+	Region                  string
+	AllowedSubscriptions    string
+	ProwJobName             string
+	Labels                  map[string]string
+	Annotations             map[string]string
+	EnvironmentVars         map[string]string
+	PollInterval            time.Duration
+	Timeout                 time.Duration
+	ProwToken               string
+	GangwayURL              string
+	ProwURL                 string
+	DryRun                  bool
+	GatePromotion           bool
+	AllowEV2Retry           bool
+	MaxEV2AutoRetryFailures int
 
 	// Git ref options for postsubmit execution
 	BaseSha string
@@ -283,26 +287,27 @@ func (o *ValidatedExecuteOptions) Complete(ctx context.Context) (*ExecuteOptions
 
 	return &ExecuteOptions{
 		completedExecuteOptions: &completedExecuteOptions{
-			Cloud:                o.Cloud,
-			Environment:          o.Environment,
-			Region:               o.Region,
-			AllowedSubscriptions: o.AllowedSubscriptions,
-			ProwJobName:          o.ProwJobName,
-			Labels:               o.ParsedLabels,
-			Annotations:          o.ParsedAnnotations,
-			EnvironmentVars:      o.ParsedEnvironmentVars,
-			PollInterval:         o.PollInterval,
-			Timeout:              o.Timeout,
-			ProwToken:            completed.ProwToken,
-			GangwayURL:           o.GangwayURL,
-			ProwURL:              o.ProwURL,
-			DryRun:               o.DryRun,
-			GatePromotion:        o.GatePromotion,
-			AllowEV2Retry:        o.AllowEV2Retry,
-			BaseSha:              o.BaseSha,
-			BaseRef:              o.BaseRef,
-			Org:                  o.Org,
-			Repo:                 o.Repo,
+			Cloud:                   o.Cloud,
+			Environment:             o.Environment,
+			Region:                  o.Region,
+			AllowedSubscriptions:    o.AllowedSubscriptions,
+			ProwJobName:             o.ProwJobName,
+			Labels:                  o.ParsedLabels,
+			Annotations:             o.ParsedAnnotations,
+			EnvironmentVars:         o.ParsedEnvironmentVars,
+			PollInterval:            o.PollInterval,
+			Timeout:                 o.Timeout,
+			ProwToken:               completed.ProwToken,
+			GangwayURL:              o.GangwayURL,
+			ProwURL:                 o.ProwURL,
+			DryRun:                  o.DryRun,
+			GatePromotion:           o.GatePromotion,
+			AllowEV2Retry:           o.AllowEV2Retry,
+			MaxEV2AutoRetryFailures: o.MaxEV2AutoRetryFailures,
+			BaseSha:                 o.BaseSha,
+			BaseRef:                 o.BaseRef,
+			Org:                     o.Org,
+			Repo:                    o.Repo,
 		},
 	}, nil
 }
@@ -317,7 +322,7 @@ func (o *ExecuteOptions) Execute(ctx context.Context) error {
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
 
 	// Create job monitor
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion, o.AllowEV2Retry)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion, o.AllowEV2Retry, o.MaxEV2AutoRetryFailures)
 
 	// Prepare environment variables, including the region
 	envs := make(map[string]string)
@@ -520,7 +525,7 @@ func (o *ValidatedMonitorOptions) Complete(ctx context.Context) (*MonitorOptions
 func (o *MonitorOptions) Monitor(ctx context.Context, logger logr.Logger) error {
 	// Create Prow client and monitor
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false, false)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false, false, prowjob.DefaultMaxEV2AutoRetryFailures)
 
 	// Monitor existing job using shared polling logic
 	logger.Info("Starting to monitor existing job", "jobExecutionID", o.JobExecutionID)

--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -85,7 +85,7 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&o.ProwURL, "prow-url", o.ProwURL, "Prow API URL for job status monitoring")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print which job would be started, but do not start one.")
 	cmd.Flags().BoolVar(&o.GatePromotion, "gate-promotion", o.GatePromotion, "Exit with an error code if the job fails.")
-	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, fail with a distinct, matchable error if its finished.json metadata marks the failure as narrow enough to safely retry, so the gating step's EV2 automatedRetry re-runs the whole step (AROSLSRE-1721). Does not resubmit the job itself.")
+	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, fail with a distinct, matchable error if its finished.json metadata marks the failure as narrow enough to safely retry, so the gating step's EV2 automatedRetry re-runs the whole step. Does not resubmit the job itself.")
 	cmd.Flags().IntVar(&o.MaxEV2AutoRetryFailures, "max-ev2-auto-retry-failures", o.MaxEV2AutoRetryFailures, "Maximum number of failed tests (all labeled allow-retry) a job may have and still qualify for an automatic EV2 gating retry. Has no effect unless allow-ev2-retry is set.")
 	cmd.Flags().StringVar(&o.BaseSha, "base-sha", o.BaseSha, "Git commit SHA to test against. When set, the job is triggered as a postsubmit with this specific commit instead of HEAD.")
 	cmd.Flags().StringVar(&o.BaseRef, "base-ref", o.BaseRef, "Git base ref (branch) for the postsubmit job (requires --base-sha)")

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -16,6 +16,7 @@ package prowjob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,21 @@ import (
 	prowgangway "sigs.k8s.io/prow/pkg/gangway"
 )
 
+// JobFailedError indicates a Prow job completed in the "failure" state - as
+// opposed to "error" or "aborted", which usually indicate an infra problem or
+// a cancellation rather than a test failure - or timed out. Only jobs that
+// failed this way are candidates for the EV2 auto-retry, since that's the
+// class of failure the allow-retry test label and EV2_RETRY_ALLOWED marker
+// are about (see AROSLSRE-1721).
+type JobFailedError struct {
+	ProwExecutionID string
+	JobURL          string
+}
+
+func (e *JobFailedError) Error() string {
+	return fmt.Sprintf("job %s failed - check the Prow UI for detailed logs: %s", e.ProwExecutionID, e.JobURL)
+}
+
 // Monitor handles job execution and monitoring
 type Monitor struct {
 	client        *Client
@@ -32,16 +48,27 @@ type Monitor struct {
 	timeout       time.Duration
 	dryRun        bool
 	gatePromotion bool
+	allowEV2Retry bool
+
+	// checkRetryMarker fetches the build log at a job's status URL and reports
+	// whether it carries the EV2_RETRY_ALLOWED marker. Defaults to
+	// buildLogContainsEV2RetryMarker; overridable in tests.
+	checkRetryMarker func(ctx context.Context, jobURL string) (bool, error)
 }
 
 // NewMonitor creates a new job monitor with the specified polling interval and timeout.
-func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion bool) *Monitor {
+// allowEV2Retry opts into automatically resubmitting the job exactly once when it
+// fails and its build log carries the EV2_RETRY_ALLOWED marker (see AROSLSRE-1721);
+// it has no effect unless gatePromotion is also true.
+func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool) *Monitor {
 	return &Monitor{
-		client:        client,
-		pollInterval:  pollInterval,
-		timeout:       timeout,
-		dryRun:        dryRun,
-		gatePromotion: gatePromotion,
+		client:           client,
+		pollInterval:     pollInterval,
+		timeout:          timeout,
+		dryRun:           dryRun,
+		gatePromotion:    gatePromotion,
+		allowEV2Retry:    allowEV2Retry,
+		checkRetryMarker: buildLogContainsEV2RetryMarker,
 	}
 }
 
@@ -75,7 +102,7 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 				return nil
 			case string(prowjobs.FailureState):
 				if m.gatePromotion {
-					return fmt.Errorf("job %s failed - check the Prow UI for detailed logs: %s", prowExecutionID, job.Status.URL)
+					return &JobFailedError{ProwExecutionID: prowExecutionID, JobURL: job.Status.URL}
 				} else {
 					logger.Error(err, "Unexpected job state, but gating is not requested.")
 					return nil
@@ -109,8 +136,41 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 	}
 }
 
-// ExecuteAndWait submits a job and waits for completion
+// ExecuteAndWait submits a job and waits for completion. If the job fails
+// (JobFailedError) and this Monitor has allowEV2Retry set, it fetches the
+// failed job's build log and, if it carries the EV2_RETRY_ALLOWED marker
+// (only known-issue tests failed, see AROSLSRE-1721), resubmits the job
+// exactly once instead of failing the gating step outright.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
+	err := m.executeAndWaitOnce(ctx, logger, request)
+	if err == nil || !m.allowEV2Retry {
+		return err
+	}
+
+	var failedErr *JobFailedError
+	if !errors.As(err, &failedErr) {
+		return err
+	}
+
+	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL)
+	if checkErr != nil {
+		logger.Error(checkErr, "Failed to inspect build log for the EV2 retry marker, not retrying", "prowExecutionID", failedErr.ProwExecutionID)
+		return err
+	}
+	if !retry {
+		return err
+	}
+
+	logger.Info("EV2_RETRY_ALLOWED marker found in build log, retrying the job once", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
+
+	// Disable further auto-retries on the retried attempt so we never retry more than once.
+	retryMonitor := *m
+	retryMonitor.allowEV2Retry = false
+	return retryMonitor.executeAndWaitOnce(ctx, logger, request)
+}
+
+// executeAndWaitOnce submits a job once and waits for it to complete, without any retry logic.
+func (m *Monitor) executeAndWaitOnce(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
 	// Submit job
 	logger.Info("Submitting Prow job", "jobName", request.JobName)
 	if m.dryRun {

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -41,6 +41,30 @@ func (e *JobFailedError) Error() string {
 	return fmt.Sprintf("job %s failed - check the Prow UI for detailed logs: %s", e.ProwExecutionID, e.JobURL)
 }
 
+// EV2RetryableMarker is the fixed, matchable substring prow-job-executor emits when a
+// gating job failure is eligible for an automatic EV2 retry (see ev2RetryEligible). The
+// EV2 gating step's pipeline.yaml configures automatedRetry.errorContainsAny with this
+// marker, so EV2 - not prow-job-executor - re-runs the whole step from scratch when it
+// sees the marker in the step's captured error output. prow-job-executor never resubmits
+// the job itself; it only decides whether the failure qualifies and surfaces that
+// decision through the error text.
+const EV2RetryableMarker = "ev2-retryable-known-issue-failure"
+
+// EV2RetryableError wraps a job failure that finished.json's metadata marks as safe to
+// auto-retry. Its Error() text always contains EV2RetryableMarker, so EV2's
+// automatedRetry.errorContainsAny can match on it and re-run the gating step.
+type EV2RetryableError struct {
+	Cause error
+}
+
+func (e *EV2RetryableError) Error() string {
+	return fmt.Sprintf("%s: %s", EV2RetryableMarker, e.Cause.Error())
+}
+
+func (e *EV2RetryableError) Unwrap() error {
+	return e.Cause
+}
+
 // Monitor handles job execution and monitoring
 type Monitor struct {
 	client               *Client
@@ -58,12 +82,13 @@ type Monitor struct {
 }
 
 // NewMonitor creates a new job monitor with the specified polling interval and timeout.
-// allowEV2Retry opts into automatically resubmitting the job exactly once when it fails
-// and its finished.json metadata marks it as safe to retry (see AROSLSRE-1721); it has no
-// effect unless gatePromotion is also true. maxAutoRetryFailures caps how many failed
-// tests a run may have (all labeled allow-retry) and still qualify; pass
-// DefaultMaxEV2AutoRetryFailures unless a caller wants to tune it without an ARO-HCP
-// rebuild.
+// allowEV2Retry opts into checking a failed job's finished.json metadata and, if it marks
+// the failure as safe to retry (see AROSLSRE-1721), failing with EV2RetryableError instead
+// of a plain JobFailedError - so the EV2 gating step's automatedRetry re-runs the whole
+// step, rather than prow-job-executor resubmitting the job itself. It has no effect unless
+// gatePromotion is also true. maxAutoRetryFailures caps how many failed tests a run may
+// have (all labeled allow-retry) and still qualify; pass DefaultMaxEV2AutoRetryFailures
+// unless a caller wants to tune it without an ARO-HCP rebuild.
 func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool, maxAutoRetryFailures int) *Monitor {
 	return &Monitor{
 		client:               client,
@@ -141,48 +166,17 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 	}
 }
 
-// ExecuteAndWait submits a job and waits for completion. If the job fails
-// (JobFailedError) and this Monitor has allowEV2Retry set, it fetches the
-// failed job's finished.json and, if its metadata marks it as safe to retry
-// (only known-issue tests failed, see AROSLSRE-1721), resubmits the job
-// exactly once instead of failing the gating step outright.
+// ExecuteAndWait submits a job once and waits for completion. It never resubmits the job
+// itself. If the job fails (JobFailedError) and this Monitor has allowEV2Retry set, it
+// fetches the failed job's finished.json and, if its metadata marks it as safe to retry
+// (only known-issue tests failed, see AROSLSRE-1721), returns an EV2RetryableError instead
+// of the plain JobFailedError. The EV2 gating step's pipeline.yaml matches
+// EV2RetryableMarker via automatedRetry.errorContainsAny and re-runs the whole step from
+// scratch - prow-job-executor only decides eligibility, EV2 owns the actual retry.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
-	// Bound the whole step, retry included, by the caller's timeout. Each
-	// attempt applies m.timeout again inside WaitForCompletion, which can only
-	// tighten this, so a retry gets whatever the first attempt left rather than
-	// a second full timeout on top.
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	err := m.executeAndWaitOnce(ctx, logger, request)
-	if err == nil || !m.allowEV2Retry {
-		return err
-	}
-
-	var failedErr *JobFailedError
-	if !errors.As(err, &failedErr) {
-		return err
-	}
-
-	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL, m.maxAutoRetryFailures)
-	if checkErr != nil {
-		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, not retrying", "prowExecutionID", failedErr.ProwExecutionID)
-		return err
-	}
-	if !retry {
-		return err
-	}
-
-	logger.Info("finished.json marks the run as safe to retry, retrying the job once", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
-
-	// Disable further auto-retries on the retried attempt so we never retry more than once.
-	retryMonitor := *m
-	retryMonitor.allowEV2Retry = false
-	return retryMonitor.executeAndWaitOnce(ctx, logger, request)
-}
-
-// executeAndWaitOnce submits a job once and waits for it to complete, without any retry logic.
-func (m *Monitor) executeAndWaitOnce(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
 	// Submit job
 	logger.Info("Submitting Prow job", "jobName", request.JobName)
 	if m.dryRun {
@@ -196,6 +190,25 @@ func (m *Monitor) executeAndWaitOnce(ctx context.Context, logger logr.Logger, re
 
 	logger.Info("Job submitted successfully", "prowExecutionID", prowExecutionID, "jobName", request.JobName)
 
-	// Wait for completion using shared logic
-	return m.WaitForCompletion(ctx, logger, prowExecutionID)
+	err = m.WaitForCompletion(ctx, logger, prowExecutionID)
+	if err == nil || !m.allowEV2Retry {
+		return err
+	}
+
+	var failedErr *JobFailedError
+	if !errors.As(err, &failedErr) {
+		return err
+	}
+
+	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL, m.maxAutoRetryFailures)
+	if checkErr != nil {
+		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, failing normally", "prowExecutionID", failedErr.ProwExecutionID)
+		return err
+	}
+	if !retry {
+		return err
+	}
+
+	logger.Info("finished.json marks the run as safe to retry, failing with the EV2-retryable marker so the gating step's automatedRetry re-runs it", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
+	return &EV2RetryableError{Cause: err}
 }

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -43,32 +43,37 @@ func (e *JobFailedError) Error() string {
 
 // Monitor handles job execution and monitoring
 type Monitor struct {
-	client        *Client
-	pollInterval  time.Duration
-	timeout       time.Duration
-	dryRun        bool
-	gatePromotion bool
-	allowEV2Retry bool
+	client               *Client
+	pollInterval         time.Duration
+	timeout              time.Duration
+	dryRun               bool
+	gatePromotion        bool
+	allowEV2Retry        bool
+	maxAutoRetryFailures int
 
 	// checkRetryMarker fetches finished.json for a job's status URL and reports
 	// whether its metadata marks the run as safe to auto-retry. Defaults to
 	// jobAllowsEV2Retry; overridable in tests.
-	checkRetryMarker func(ctx context.Context, jobURL string) (bool, error)
+	checkRetryMarker func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error)
 }
 
 // NewMonitor creates a new job monitor with the specified polling interval and timeout.
-// allowEV2Retry opts into automatically resubmitting the job exactly once when it
-// fails and its finished.json metadata marks it as safe to retry (see AROSLSRE-1721);
-// it has no effect unless gatePromotion is also true.
-func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool) *Monitor {
+// allowEV2Retry opts into automatically resubmitting the job exactly once when it fails
+// and its finished.json metadata marks it as safe to retry (see AROSLSRE-1721); it has no
+// effect unless gatePromotion is also true. maxAutoRetryFailures caps how many failed
+// tests a run may have (all labeled allow-retry) and still qualify; pass
+// DefaultMaxEV2AutoRetryFailures unless a caller wants to tune it without an ARO-HCP
+// rebuild.
+func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool, maxAutoRetryFailures int) *Monitor {
 	return &Monitor{
-		client:           client,
-		pollInterval:     pollInterval,
-		timeout:          timeout,
-		dryRun:           dryRun,
-		gatePromotion:    gatePromotion,
-		allowEV2Retry:    allowEV2Retry,
-		checkRetryMarker: jobAllowsEV2Retry,
+		client:               client,
+		pollInterval:         pollInterval,
+		timeout:              timeout,
+		dryRun:               dryRun,
+		gatePromotion:        gatePromotion,
+		allowEV2Retry:        allowEV2Retry,
+		maxAutoRetryFailures: maxAutoRetryFailures,
+		checkRetryMarker:     jobAllowsEV2Retry,
 	}
 }
 
@@ -159,7 +164,7 @@ func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, reques
 		return err
 	}
 
-	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL)
+	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL, m.maxAutoRetryFailures)
 	if checkErr != nil {
 		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, not retrying", "prowExecutionID", failedErr.ProwExecutionID)
 		return err

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -142,6 +142,13 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 // (only known-issue tests failed, see AROSLSRE-1721), resubmits the job
 // exactly once instead of failing the gating step outright.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
+	// Bound the whole step, retry included, by the caller's timeout. Each
+	// attempt applies m.timeout again inside WaitForCompletion, which can only
+	// tighten this, so a retry gets whatever the first attempt left rather than
+	// a second full timeout on top.
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
 	err := m.executeAndWaitOnce(ctx, logger, request)
 	if err == nil || !m.allowEV2Retry {
 		return err

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -30,8 +30,8 @@ import (
 // opposed to "error" or "aborted", which usually indicate an infra problem or
 // a cancellation rather than a test failure - or timed out. Only jobs that
 // failed this way are candidates for the EV2 auto-retry, since that's the
-// class of failure the allow-retry test label and EV2_RETRY_ALLOWED marker
-// are about (see AROSLSRE-1721).
+// class of failure the allow-retry test label and finished.json retry
+// metadata are about (see AROSLSRE-1721).
 type JobFailedError struct {
 	ProwExecutionID string
 	JobURL          string
@@ -50,15 +50,15 @@ type Monitor struct {
 	gatePromotion bool
 	allowEV2Retry bool
 
-	// checkRetryMarker fetches the build log at a job's status URL and reports
-	// whether it carries the EV2_RETRY_ALLOWED marker. Defaults to
-	// buildLogContainsEV2RetryMarker; overridable in tests.
+	// checkRetryMarker fetches finished.json for a job's status URL and reports
+	// whether its metadata marks the run as safe to auto-retry. Defaults to
+	// jobAllowsEV2Retry; overridable in tests.
 	checkRetryMarker func(ctx context.Context, jobURL string) (bool, error)
 }
 
 // NewMonitor creates a new job monitor with the specified polling interval and timeout.
 // allowEV2Retry opts into automatically resubmitting the job exactly once when it
-// fails and its build log carries the EV2_RETRY_ALLOWED marker (see AROSLSRE-1721);
+// fails and its finished.json metadata marks it as safe to retry (see AROSLSRE-1721);
 // it has no effect unless gatePromotion is also true.
 func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool) *Monitor {
 	return &Monitor{
@@ -68,7 +68,7 @@ func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gat
 		dryRun:           dryRun,
 		gatePromotion:    gatePromotion,
 		allowEV2Retry:    allowEV2Retry,
-		checkRetryMarker: buildLogContainsEV2RetryMarker,
+		checkRetryMarker: jobAllowsEV2Retry,
 	}
 }
 
@@ -138,7 +138,7 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 
 // ExecuteAndWait submits a job and waits for completion. If the job fails
 // (JobFailedError) and this Monitor has allowEV2Retry set, it fetches the
-// failed job's build log and, if it carries the EV2_RETRY_ALLOWED marker
+// failed job's finished.json and, if its metadata marks it as safe to retry
 // (only known-issue tests failed, see AROSLSRE-1721), resubmits the job
 // exactly once instead of failing the gating step outright.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
@@ -161,14 +161,14 @@ func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, reques
 
 	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL)
 	if checkErr != nil {
-		logger.Error(checkErr, "Failed to inspect build log for the EV2 retry marker, not retrying", "prowExecutionID", failedErr.ProwExecutionID)
+		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, not retrying", "prowExecutionID", failedErr.ProwExecutionID)
 		return err
 	}
 	if !retry {
 		return err
 	}
 
-	logger.Info("EV2_RETRY_ALLOWED marker found in build log, retrying the job once", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
+	logger.Info("finished.json marks the run as safe to retry, retrying the job once", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
 
 	// Disable further auto-retries on the retried attempt so we never retry more than once.
 	retryMonitor := *m

--- a/tools/prow-job-executor/prowjob/monitor_test.go
+++ b/tools/prow-job-executor/prowjob/monitor_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	prowgangway "sigs.k8s.io/prow/pkg/gangway"
+)
+
+// newTestServers spins up fake gangway (submit) and prow (status) endpoints.
+// Each submission gets a sequentially numbered job ID ("job-1", "job-2", ...)
+// whose reported state is taken from states, in order (the last entry repeats
+// once exhausted).
+func newTestServers(t *testing.T, states []string) (client *Client, submitCount *int32) {
+	t.Helper()
+
+	var submits int32
+	var prowSrv *httptest.Server
+
+	gangwaySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&submits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"id":"job-%d"}`, n)
+	}))
+	t.Cleanup(gangwaySrv.Close)
+
+	prowSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("prowjob")
+		var idx int
+		_, _ = fmt.Sscanf(id, "job-%d", &idx)
+		idx-- // job-1 -> states[0]
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(states) {
+			idx = len(states) - 1
+		}
+		state := states[idx]
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "status:\n  state: %s\n  url: https://prow.ci.openshift.org/view/gs/bucket/%s\nspec:\n  job: test-job\n", state, id)
+	}))
+	t.Cleanup(prowSrv.Close)
+
+	c := NewClient("test-token", gangwaySrv.URL, prowSrv.URL)
+	return c, &submits
+}
+
+func TestExecuteAndWaitRetriesOnceWhenMarkerFound(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure", "success"})
+
+	var markerChecks int32
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+		atomic.AddInt32(&markerChecks, 1)
+		if !strings.Contains(jobURL, "job-1") {
+			t.Fatalf("expected marker check against the first (failed) job, got %q", jobURL)
+		}
+		return true, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err != nil {
+		t.Fatalf("expected the retried job to succeed, got error: %v", err)
+	}
+	if got := atomic.LoadInt32(submitCount); got != 2 {
+		t.Fatalf("expected 2 submissions (original + 1 retry), got %d", got)
+	}
+	if got := atomic.LoadInt32(&markerChecks); got != 1 {
+		t.Fatalf("expected exactly 1 marker check, got %d", got)
+	}
+}
+
+func TestExecuteAndWaitDoesNotRetryWhenMarkerAbsent(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure", "success"})
+
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+		return false, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected the job failure to propagate when no marker is found, got nil")
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission (no retry), got %d", got)
+	}
+}
+
+func TestExecuteAndWaitDoesNotRetryTwice(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure", "failure"})
+
+	var markerChecks int32
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+		atomic.AddInt32(&markerChecks, 1)
+		return true, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected an error since the retried job also failed")
+	}
+	if got := atomic.LoadInt32(submitCount); got != 2 {
+		t.Fatalf("expected exactly 2 submissions (original + the single retry, no further retry), got %d", got)
+	}
+	if got := atomic.LoadInt32(&markerChecks); got != 1 {
+		t.Fatalf("expected exactly 1 marker check (the retried attempt has allowEV2Retry disabled), got %d", got)
+	}
+}
+
+func TestExecuteAndWaitSkipsRetryWhenNotAllowed(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
+
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, false)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+		t.Fatal("checkRetryMarker should not be called when allowEV2Retry is false")
+		return false, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected the job failure to propagate")
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission, got %d", got)
+	}
+}

--- a/tools/prow-job-executor/prowjob/monitor_test.go
+++ b/tools/prow-job-executor/prowjob/monitor_test.go
@@ -71,8 +71,8 @@ func TestExecuteAndWaitRetriesOnceWhenMarkerFound(t *testing.T) {
 	client, submitCount := newTestServers(t, []string{"failure", "success"})
 
 	var markerChecks int32
-	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
-	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
 		atomic.AddInt32(&markerChecks, 1)
 		if !strings.Contains(jobURL, "job-1") {
 			t.Fatalf("expected marker check against the first (failed) job, got %q", jobURL)
@@ -95,8 +95,8 @@ func TestExecuteAndWaitRetriesOnceWhenMarkerFound(t *testing.T) {
 func TestExecuteAndWaitDoesNotRetryWhenMarkerAbsent(t *testing.T) {
 	client, submitCount := newTestServers(t, []string{"failure", "success"})
 
-	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
-	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
 		return false, nil
 	}
 
@@ -113,8 +113,8 @@ func TestExecuteAndWaitDoesNotRetryTwice(t *testing.T) {
 	client, submitCount := newTestServers(t, []string{"failure", "failure"})
 
 	var markerChecks int32
-	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true)
-	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
 		atomic.AddInt32(&markerChecks, 1)
 		return true, nil
 	}
@@ -134,8 +134,8 @@ func TestExecuteAndWaitDoesNotRetryTwice(t *testing.T) {
 func TestExecuteAndWaitSkipsRetryWhenNotAllowed(t *testing.T) {
 	client, submitCount := newTestServers(t, []string{"failure"})
 
-	m := NewMonitor(client, time.Millisecond, time.Second, false, true, false)
-	m.checkRetryMarker = func(ctx context.Context, jobURL string) (bool, error) {
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, false, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
 		t.Fatal("checkRetryMarker should not be called when allowEV2Retry is false")
 		return false, nil
 	}

--- a/tools/prow-job-executor/prowjob/monitor_test.go
+++ b/tools/prow-job-executor/prowjob/monitor_test.go
@@ -16,6 +16,7 @@ package prowjob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -67,33 +68,40 @@ func newTestServers(t *testing.T, states []string) (client *Client, submitCount 
 	return c, &submits
 }
 
-func TestExecuteAndWaitRetriesOnceWhenMarkerFound(t *testing.T) {
-	client, submitCount := newTestServers(t, []string{"failure", "success"})
+func TestExecuteAndWaitFailsWithMarkerWhenEligible(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
 
 	var markerChecks int32
 	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
 	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
 		atomic.AddInt32(&markerChecks, 1)
 		if !strings.Contains(jobURL, "job-1") {
-			t.Fatalf("expected marker check against the first (failed) job, got %q", jobURL)
+			t.Fatalf("expected marker check against the failed job, got %q", jobURL)
 		}
 		return true, nil
 	}
 
 	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
-	if err != nil {
-		t.Fatalf("expected the retried job to succeed, got error: %v", err)
+	if err == nil {
+		t.Fatal("expected an error even when the failure is retry-eligible - prow-job-executor never resubmits the job itself")
 	}
-	if got := atomic.LoadInt32(submitCount); got != 2 {
-		t.Fatalf("expected 2 submissions (original + 1 retry), got %d", got)
+	var retryable *EV2RetryableError
+	if !errors.As(err, &retryable) {
+		t.Fatalf("expected an EV2RetryableError so EV2's automatedRetry can match on it, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), EV2RetryableMarker) {
+		t.Fatalf("expected the error text to contain %q, got %q", EV2RetryableMarker, err.Error())
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission (prow-job-executor must not resubmit), got %d", got)
 	}
 	if got := atomic.LoadInt32(&markerChecks); got != 1 {
 		t.Fatalf("expected exactly 1 marker check, got %d", got)
 	}
 }
 
-func TestExecuteAndWaitDoesNotRetryWhenMarkerAbsent(t *testing.T) {
-	client, submitCount := newTestServers(t, []string{"failure", "success"})
+func TestExecuteAndWaitFailsPlainWhenMarkerAbsent(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
 
 	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
 	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
@@ -104,34 +112,16 @@ func TestExecuteAndWaitDoesNotRetryWhenMarkerAbsent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected the job failure to propagate when no marker is found, got nil")
 	}
+	var retryable *EV2RetryableError
+	if errors.As(err, &retryable) {
+		t.Fatalf("expected a plain error (not EV2-retryable) when the failure is not eligible, got: %v", err)
+	}
 	if got := atomic.LoadInt32(submitCount); got != 1 {
-		t.Fatalf("expected exactly 1 submission (no retry), got %d", got)
+		t.Fatalf("expected exactly 1 submission, got %d", got)
 	}
 }
 
-func TestExecuteAndWaitDoesNotRetryTwice(t *testing.T) {
-	client, submitCount := newTestServers(t, []string{"failure", "failure"})
-
-	var markerChecks int32
-	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
-	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
-		atomic.AddInt32(&markerChecks, 1)
-		return true, nil
-	}
-
-	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
-	if err == nil {
-		t.Fatal("expected an error since the retried job also failed")
-	}
-	if got := atomic.LoadInt32(submitCount); got != 2 {
-		t.Fatalf("expected exactly 2 submissions (original + the single retry, no further retry), got %d", got)
-	}
-	if got := atomic.LoadInt32(&markerChecks); got != 1 {
-		t.Fatalf("expected exactly 1 marker check (the retried attempt has allowEV2Retry disabled), got %d", got)
-	}
-}
-
-func TestExecuteAndWaitSkipsRetryWhenNotAllowed(t *testing.T) {
+func TestExecuteAndWaitSkipsMarkerCheckWhenNotAllowed(t *testing.T) {
 	client, submitCount := newTestServers(t, []string{"failure"})
 
 	m := NewMonitor(client, time.Millisecond, time.Second, false, true, false, DefaultMaxEV2AutoRetryFailures)

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -27,14 +27,31 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// ev2RetryMetadataKey is the finished.json metadata key that the ARO-HCP E2E
-// test binary (aro-hcp-tests, see AROSLSRE-1721) sets to true when a run's
-// failures are narrow enough to safely auto-retry: at most 2 tests failed,
-// and every one of them was labeled allow-retry. aro-hcp-tests writes this
-// key into $ARTIFACT_DIR/metadata.json, which Prow's sidecar merges into the
-// job's finished.json under the top-level "metadata" object - the standard
-// Prow custom-metadata mechanism, so no log scraping is involved.
-const ev2RetryMetadataKey = "ev2-retry-allowed"
+// ev2FailedTestsKey and ev2AllowRetryTestsKey are the finished.json metadata keys that the
+// ARO-HCP E2E test binary (aro-hcp-tests, see AROSLSRE-1721) always writes once a run
+// finishes: the full list of failed spec names, and the subset of those that were labeled
+// allow-retry (a known, tracked issue with a fix already committed to). aro-hcp-tests
+// writes both keys into $ARTIFACT_DIR/metadata.json, which Prow's sidecar merges into the
+// job's finished.json under the top-level "metadata" object - the standard Prow
+// custom-metadata mechanism, so no log scraping is involved.
+//
+// aro-hcp-tests only reports these raw facts, even when nothing failed (both lists empty);
+// it is prow-job-executor's job (ev2RetryEligible below) to decide whether the shape of a
+// failure is narrow enough to safely auto-retry. Keeping the policy here, rather than baked
+// into an ARO-HCP release, means the retry threshold can be tuned without an ARO-HCP
+// rebuild, and an absent key unambiguously means "this step never ran" rather than
+// "the run failed but wasn't retry-eligible".
+const (
+	ev2FailedTestsKey     = "ev2-failed-tests"
+	ev2AllowRetryTestsKey = "ev2-allow-retry-tests"
+)
+
+// DefaultMaxEV2AutoRetryFailures caps how many failed tests a run may have and still
+// qualify for an automatic EV2 gating retry. If more tests than this fail, or any failure
+// isn't labeled allow-retry, we stay silent and let the gate fail normally for a human to
+// triage. Overridable via Monitor's maxAutoRetryFailures field (see the
+// --max-ev2-auto-retry-failures flag).
+const DefaultMaxEV2AutoRetryFailures = 2
 
 // maxFinishedJSONBytes bounds how much of finished.json we'll read. The file
 // is a small, flat JSON document; anything near this size indicates something
@@ -77,21 +94,22 @@ func finishedJSONURLFromViewURL(viewURL string) (string, error) {
 	return fmt.Sprintf("https://storage.googleapis.com/%s/finished.json", gcsPath), nil
 }
 
-// jobAllowsEV2Retry fetches finished.json for the job reported at viewURL and
-// reports whether its metadata carries ev2RetryMetadataKey=true.
-func jobAllowsEV2Retry(ctx context.Context, viewURL string) (bool, error) {
+// jobAllowsEV2Retry fetches finished.json for the job reported at viewURL and reports
+// whether its ev2FailedTestsKey/ev2AllowRetryTestsKey metadata qualifies for an automatic
+// EV2 gating retry, per ev2RetryEligible.
+func jobAllowsEV2Retry(ctx context.Context, viewURL string, maxAutoRetryFailures int) (bool, error) {
 	rawURL, err := finishedJSONURLFromViewURL(viewURL)
 	if err != nil {
 		return false, err
 	}
-	return fetchFinishedJSONAllowsRetry(ctx, rawURL)
+	return fetchFinishedJSONAllowsRetry(ctx, rawURL, maxAutoRetryFailures)
 }
 
-// fetchFinishedJSONAllowsRetry downloads rawURL as a finished.json document
-// and reports whether its metadata carries ev2RetryMetadataKey=true. Split out
-// from jobAllowsEV2Retry so the HTTP fetch/parse logic can be tested against a
-// local httptest server, independent of GCS URL construction.
-func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string) (bool, error) {
+// fetchFinishedJSONAllowsRetry downloads rawURL as a finished.json document and reports
+// whether its metadata qualifies for an automatic EV2 gating retry. Split out from
+// jobAllowsEV2Retry so the HTTP fetch/parse logic can be tested against a local httptest
+// server, independent of GCS URL construction.
+func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string, maxAutoRetryFailures int) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, finishedJSONFetchTimeout)
 	defer cancel()
 
@@ -124,6 +142,50 @@ func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string) (bool, err
 		return false, fmt.Errorf("failed to decode finished.json %q: %w", rawURL, err)
 	}
 
-	allow, _ := finished.Metadata[ev2RetryMetadataKey].(bool)
-	return allow, nil
+	failed := stringSliceFromMetadata(finished.Metadata, ev2FailedTestsKey)
+	allowRetry := stringSliceFromMetadata(finished.Metadata, ev2AllowRetryTestsKey)
+	return ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures), nil
+}
+
+// stringSliceFromMetadata extracts a []string out of finished.json's loosely-typed
+// metadata map for the given key, tolerating a missing or malformed key by returning nil -
+// callers treat a missing list the same as an empty one.
+func stringSliceFromMetadata(metadata map[string]interface{}, key string) []string {
+	raw, ok := metadata[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ev2RetryEligible decides whether a finished run qualifies for an automatic EV2 gating
+// retry, given the raw facts aro-hcp-tests reported: every test name that failed, and the
+// subset of those that were labeled allow-retry (a known, tracked issue). This is the
+// whole eligibility policy, kept separate from the HTTP fetch/parse logic above so it can
+// be tested directly.
+//
+// A run qualifies only when it failed at all, no more than maxAutoRetryFailures tests
+// failed, and every failure was labeled allow-retry. Any other shape - too many failures,
+// or even a single failure not carrying the label - disqualifies the whole run, so the
+// gate fails normally and a human triages it.
+func ev2RetryEligible(failed, allowRetry []string, maxAutoRetryFailures int) bool {
+	if len(failed) == 0 || len(failed) > maxAutoRetryFailures {
+		return false
+	}
+	allowRetrySet := make(map[string]bool, len(allowRetry))
+	for _, name := range allowRetry {
+		allowRetrySet[name] = true
+	}
+	for _, name := range failed {
+		if !allowRetrySet[name] {
+			return false
+		}
+	}
+	return true
 }

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // ev2RetryMarker is the exact log line prefix that the ARO-HCP E2E test binary
@@ -89,7 +91,11 @@ func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch build log %q: %w", rawLogURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logr.FromContextOrDiscard(ctx).Error(err, "failed to close body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("failed to fetch build log %q: unexpected status %d", rawLogURL, resp.StatusCode)

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ev2RetryMarker is the exact log line prefix that the ARO-HCP E2E test binary
+// (aro-hcp-tests, see AROSLSRE-1721) prints when a run's failures are narrow
+// enough to safely auto-retry: at most 2 tests failed, and every one of them
+// was labeled allow-retry.
+const ev2RetryMarker = "EV2_RETRY_ALLOWED:"
+
+// maxBuildLogBytes caps how much of the build log we read looking for the
+// retry marker, so a huge or slow log can't stall or blow up memory.
+const maxBuildLogBytes = 4 << 20 // 4 MiB
+
+// buildLogFetchTimeout bounds a single build-log fetch, independent of the
+// overall job-monitoring timeout.
+const buildLogFetchTimeout = 30 * time.Second
+
+// buildLogURLFromViewURL converts a Prow Deck "view" URL (the one reported in
+// ProwJob.Status.URL, e.g.
+// https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/<job>/<build>)
+// into the plain-text build log's public GCS URL, e.g.
+// https://storage.googleapis.com/origin-ci-test/logs/<job>/<build>/build-log.txt.
+func buildLogURLFromViewURL(viewURL string) (string, error) {
+	if viewURL == "" {
+		return "", fmt.Errorf("job has no status URL, cannot locate its build log")
+	}
+
+	u, err := url.Parse(viewURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse job status URL %q: %w", viewURL, err)
+	}
+
+	const viewPrefix = "/view/gs/"
+	if !strings.HasPrefix(u.Path, viewPrefix) {
+		return "", fmt.Errorf("job status URL %q does not look like a GCS Prow view URL (missing %q prefix)", viewURL, viewPrefix)
+	}
+
+	gcsPath := strings.Trim(strings.TrimPrefix(u.Path, viewPrefix), "/")
+	return fmt.Sprintf("https://storage.googleapis.com/%s/build-log.txt", gcsPath), nil
+}
+
+// buildLogContainsEV2RetryMarker fetches the build log for the job reported
+// at viewURL and reports whether it contains the EV2_RETRY_ALLOWED marker.
+func buildLogContainsEV2RetryMarker(ctx context.Context, viewURL string) (bool, error) {
+	rawLogURL, err := buildLogURLFromViewURL(viewURL)
+	if err != nil {
+		return false, err
+	}
+	return fetchLogContainsEV2RetryMarker(ctx, rawLogURL)
+}
+
+// fetchLogContainsEV2RetryMarker downloads rawLogURL and reports whether it
+// contains the EV2_RETRY_ALLOWED marker. Split out from
+// buildLogContainsEV2RetryMarker so the HTTP fetch/scan logic can be tested
+// against a local httptest server, independent of GCS URL construction.
+func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, buildLogFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawLogURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create build log request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch build log %q: %w", rawLogURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("failed to fetch build log %q: unexpected status %d", rawLogURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBuildLogBytes))
+	if err != nil {
+		return false, fmt.Errorf("failed to read build log %q: %w", rawLogURL, err)
+	}
+
+	return strings.Contains(string(body), ev2RetryMarker), nil
+}

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -15,8 +15,8 @@
 package prowjob
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,29 +27,40 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// ev2RetryMarker is the exact log line prefix that the ARO-HCP E2E test binary
-// (aro-hcp-tests, see AROSLSRE-1721) prints when a run's failures are narrow
-// enough to safely auto-retry: at most 2 tests failed, and every one of them
-// was labeled allow-retry.
-const ev2RetryMarker = "EV2_RETRY_ALLOWED:"
+// ev2RetryMetadataKey is the finished.json metadata key that the ARO-HCP E2E
+// test binary (aro-hcp-tests, see AROSLSRE-1721) sets to true when a run's
+// failures are narrow enough to safely auto-retry: at most 2 tests failed,
+// and every one of them was labeled allow-retry. aro-hcp-tests writes this
+// key into $ARTIFACT_DIR/metadata.json, which Prow's sidecar merges into the
+// job's finished.json under the top-level "metadata" object - the standard
+// Prow custom-metadata mechanism, so no log scraping is involved.
+const ev2RetryMetadataKey = "ev2-retry-allowed"
 
-// maxBuildLogBytes is how much of the tail of the build log we ask for. The
-// marker is printed from an AfterAll, so it lands at the end of the log, and a
-// full E2E log is far bigger than this.
-const maxBuildLogBytes = 4 << 20 // 4 MiB
+// maxFinishedJSONBytes bounds how much of finished.json we'll read. The file
+// is a small, flat JSON document; anything near this size indicates something
+// unexpected and we'd rather fail closed than buffer an unbounded response.
+const maxFinishedJSONBytes = 1 << 20 // 1 MiB
 
-// buildLogFetchTimeout bounds a single build-log fetch, independent of the
-// overall job-monitoring timeout.
-const buildLogFetchTimeout = 30 * time.Second
+// finishedJSONFetchTimeout bounds a single finished.json fetch, independent of
+// the overall job-monitoring timeout.
+const finishedJSONFetchTimeout = 30 * time.Second
 
-// buildLogURLFromViewURL converts a Prow Deck "view" URL (the one reported in
-// ProwJob.Status.URL, e.g.
+// finishedJSON is the subset of Prow's finished.json (produced by the sidecar
+// utility, see sigs.k8s.io/prow/pkg/sidecar and the testgrid metadata.Finished
+// type) that we need: the free-form metadata object merged in from each
+// step's $ARTIFACT_DIR/metadata.json.
+type finishedJSON struct {
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+// finishedJSONURLFromViewURL converts a Prow Deck "view" URL (the one
+// reported in ProwJob.Status.URL, e.g.
 // https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/<job>/<build>)
-// into the plain-text build log's public GCS URL, e.g.
-// https://storage.googleapis.com/origin-ci-test/logs/<job>/<build>/build-log.txt.
-func buildLogURLFromViewURL(viewURL string) (string, error) {
+// into finished.json's public GCS URL, e.g.
+// https://storage.googleapis.com/origin-ci-test/logs/<job>/<build>/finished.json.
+func finishedJSONURLFromViewURL(viewURL string) (string, error) {
 	if viewURL == "" {
-		return "", fmt.Errorf("job has no status URL, cannot locate its build log")
+		return "", fmt.Errorf("job has no status URL, cannot locate its finished.json")
 	}
 
 	u, err := url.Parse(viewURL)
@@ -63,39 +74,35 @@ func buildLogURLFromViewURL(viewURL string) (string, error) {
 	}
 
 	gcsPath := strings.Trim(strings.TrimPrefix(u.Path, viewPrefix), "/")
-	return fmt.Sprintf("https://storage.googleapis.com/%s/build-log.txt", gcsPath), nil
+	return fmt.Sprintf("https://storage.googleapis.com/%s/finished.json", gcsPath), nil
 }
 
-// buildLogContainsEV2RetryMarker fetches the build log for the job reported
-// at viewURL and reports whether it contains the EV2_RETRY_ALLOWED marker.
-func buildLogContainsEV2RetryMarker(ctx context.Context, viewURL string) (bool, error) {
-	rawLogURL, err := buildLogURLFromViewURL(viewURL)
+// jobAllowsEV2Retry fetches finished.json for the job reported at viewURL and
+// reports whether its metadata carries ev2RetryMetadataKey=true.
+func jobAllowsEV2Retry(ctx context.Context, viewURL string) (bool, error) {
+	rawURL, err := finishedJSONURLFromViewURL(viewURL)
 	if err != nil {
 		return false, err
 	}
-	return fetchLogContainsEV2RetryMarker(ctx, rawLogURL)
+	return fetchFinishedJSONAllowsRetry(ctx, rawURL)
 }
 
-// fetchLogContainsEV2RetryMarker downloads rawLogURL and reports whether it
-// contains the EV2_RETRY_ALLOWED marker. Split out from
-// buildLogContainsEV2RetryMarker so the HTTP fetch/scan logic can be tested
-// against a local httptest server, independent of GCS URL construction.
-func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, buildLogFetchTimeout)
+// fetchFinishedJSONAllowsRetry downloads rawURL as a finished.json document
+// and reports whether its metadata carries ev2RetryMetadataKey=true. Split out
+// from jobAllowsEV2Retry so the HTTP fetch/parse logic can be tested against a
+// local httptest server, independent of GCS URL construction.
+func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, finishedJSONFetchTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawLogURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return false, fmt.Errorf("failed to create build log request: %w", err)
+		return false, fmt.Errorf("failed to create finished.json request: %w", err)
 	}
-	// aro-hcp-tests prints the marker from an AfterAll, so it is at the end of
-	// the log. Ask for the tail, otherwise a long E2E log pushes the marker out
-	// of anything we read from the front.
-	req.Header.Set("Range", fmt.Sprintf("bytes=-%d", maxBuildLogBytes))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false, fmt.Errorf("failed to fetch build log %q: %w", rawLogURL, err)
+		return false, fmt.Errorf("failed to fetch finished.json %q: %w", rawURL, err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -103,48 +110,20 @@ func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return false, fmt.Errorf("failed to fetch build log %q: unexpected status %d", rawLogURL, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("failed to fetch finished.json %q: unexpected status %d", rawURL, resp.StatusCode)
 	}
 
-	// 206 means we got just the tail. 200 means the server ignored the Range
-	// header and is sending the whole log, so scan it as a stream rather than
-	// buffering it. Either way the fetch timeout bounds how long this runs.
-	found, err := streamContainsMarker(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFinishedJSONBytes))
 	if err != nil {
-		return false, fmt.Errorf("failed to read build log %q: %w", rawLogURL, err)
+		return false, fmt.Errorf("failed to read finished.json %q: %w", rawURL, err)
 	}
-	return found, nil
-}
 
-// streamContainsMarker reports whether r contains ev2RetryMarker, reading in
-// fixed size chunks and carrying the last len(marker)-1 bytes over so a marker
-// straddling a chunk boundary is still found. Memory stays constant regardless
-// of how big the log is.
-func streamContainsMarker(r io.Reader) (bool, error) {
-	const chunkSize = 64 << 10
-	marker := []byte(ev2RetryMarker)
-	overlap := len(marker) - 1
-	buf := make([]byte, overlap+chunkSize)
-	filled := 0
-
-	for {
-		n, err := r.Read(buf[filled:])
-		if n > 0 {
-			filled += n
-			if bytes.Contains(buf[:filled], marker) {
-				return true, nil
-			}
-			if filled > overlap {
-				copy(buf, buf[filled-overlap:filled])
-				filled = overlap
-			}
-		}
-		if err == io.EOF {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
+	var finished finishedJSON
+	if err := json.Unmarshal(body, &finished); err != nil {
+		return false, fmt.Errorf("failed to decode finished.json %q: %w", rawURL, err)
 	}
+
+	allow, _ := finished.Metadata[ev2RetryMetadataKey].(bool)
+	return allow, nil
 }

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -15,6 +15,7 @@
 package prowjob
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -32,8 +33,9 @@ import (
 // was labeled allow-retry.
 const ev2RetryMarker = "EV2_RETRY_ALLOWED:"
 
-// maxBuildLogBytes caps how much of the build log we read looking for the
-// retry marker, so a huge or slow log can't stall or blow up memory.
+// maxBuildLogBytes is how much of the tail of the build log we ask for. The
+// marker is printed from an AfterAll, so it lands at the end of the log, and a
+// full E2E log is far bigger than this.
 const maxBuildLogBytes = 4 << 20 // 4 MiB
 
 // buildLogFetchTimeout bounds a single build-log fetch, independent of the
@@ -86,6 +88,10 @@ func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool
 	if err != nil {
 		return false, fmt.Errorf("failed to create build log request: %w", err)
 	}
+	// aro-hcp-tests prints the marker from an AfterAll, so it is at the end of
+	// the log. Ask for the tail, otherwise a long E2E log pushes the marker out
+	// of anything we read from the front.
+	req.Header.Set("Range", fmt.Sprintf("bytes=-%d", maxBuildLogBytes))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -97,14 +103,48 @@ func fetchLogContainsEV2RetryMarker(ctx context.Context, rawLogURL string) (bool
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		return false, fmt.Errorf("failed to fetch build log %q: unexpected status %d", rawLogURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBuildLogBytes))
+	// 206 means we got just the tail. 200 means the server ignored the Range
+	// header and is sending the whole log, so scan it as a stream rather than
+	// buffering it. Either way the fetch timeout bounds how long this runs.
+	found, err := streamContainsMarker(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("failed to read build log %q: %w", rawLogURL, err)
 	}
+	return found, nil
+}
 
-	return strings.Contains(string(body), ev2RetryMarker), nil
+// streamContainsMarker reports whether r contains ev2RetryMarker, reading in
+// fixed size chunks and carrying the last len(marker)-1 bytes over so a marker
+// straddling a chunk boundary is still found. Memory stays constant regardless
+// of how big the log is.
+func streamContainsMarker(r io.Reader) (bool, error) {
+	const chunkSize = 64 << 10
+	marker := []byte(ev2RetryMarker)
+	overlap := len(marker) - 1
+	buf := make([]byte, overlap+chunkSize)
+	filled := 0
+
+	for {
+		n, err := r.Read(buf[filled:])
+		if n > 0 {
+			filled += n
+			if bytes.Contains(buf[:filled], marker) {
+				return true, nil
+			}
+			if filled > overlap {
+				copy(buf, buf[filled-overlap:filled])
+				filled = overlap
+			}
+		}
+		if err == io.EOF {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+	}
 }

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -19,10 +19,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 )
 
-func TestBuildLogURLFromViewURL(t *testing.T) {
+func TestFinishedJSONURLFromViewURL(t *testing.T) {
 	tests := []struct {
 		name    string
 		viewURL string
@@ -32,157 +31,135 @@ func TestBuildLogURLFromViewURL(t *testing.T) {
 		{
 			name:    "typical prow deck view URL",
 			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345",
-			want:    "https://storage.googleapis.com/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345/build-log.txt",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345/finished.json",
 		},
 		{
 			name:    "trailing slash is trimmed",
 			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/some-job/1/",
-			want:    "https://storage.googleapis.com/origin-ci-test/logs/some-job/1/build-log.txt",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/some-job/1/finished.json",
 		},
 		{
-			name:    "empty URL",
+			name:    "empty URL is an error",
 			viewURL: "",
 			wantErr: true,
 		},
 		{
-			name:    "missing /view/gs/ prefix",
-			viewURL: "https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/some-job",
+			name:    "missing /view/gs/ prefix is an error",
+			viewURL: "https://prow.ci.openshift.org/something-else/origin-ci-test/logs/some-job/1",
 			wantErr: true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildLogURLFromViewURL(tt.viewURL)
-			if tt.wantErr {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := finishedJSONURLFromViewURL(tc.viewURL)
+			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("expected an error, got url %q", got)
+					t.Fatalf("expected error, got URL %q", got)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Fatalf("got %q, want %q", got, tt.want)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestFetchLogContainsEV2RetryMarker(t *testing.T) {
+func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 	tests := []struct {
 		name       string
-		body       string
 		statusCode int
+		body       string
 		want       bool
 		wantErr    bool
 	}{
 		{
-			name:       "marker present",
-			body:       "some test output\nEV2_RETRY_ALLOWED: 1 known-issue test(s) failed (max 2 allowed), all labeled \"allow-retry\": [\"foo\"]\nmore output",
+			name:       "metadata key true",
 			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":true,"pod":"abc"}}`,
 			want:       true,
 		},
 		{
-			name:       "marker absent",
-			body:       "some test output\nsome other failure\nmore output",
+			name:       "metadata key absent",
 			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"pod":"abc"}}`,
 			want:       false,
 		},
 		{
-			name:       "non-200 status",
-			body:       "not found",
+			name:       "metadata key false",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":false}}`,
+			want:       false,
+		},
+		{
+			name:       "no metadata object at all",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE"}`,
+			want:       false,
+		},
+		{
+			name:       "metadata key wrong type is treated as absent",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":"true"}}`,
+			want:       false,
+		},
+		{
+			name:       "non-200 status is an error",
 			statusCode: http.StatusNotFound,
+			body:       "not found",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid JSON is an error",
+			statusCode: http.StatusOK,
+			body:       `{not json`,
 			wantErr:    true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.statusCode)
-				_, _ = w.Write([]byte(tt.body))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
 			}))
-			defer server.Close()
+			defer srv.Close()
 
-			got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
-			if tt.wantErr {
+			got, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL)
+			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("expected an error, got %v", got)
+					t.Fatalf("expected error, got %v", got)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Fatalf("got %v, want %v", got, tt.want)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestFetchLogContainsEV2RetryMarkerFindsMarkerAtEndOfLargeLog(t *testing.T) {
-	// The marker is printed from an AfterAll, so on a real E2E run it sits at
-	// the very end of a log far larger than maxBuildLogBytes. Reading from the
-	// front would miss it, which would silently disable the whole retry path.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log := strings.Repeat("x", maxBuildLogBytes+1024) + "\n" + ev2RetryMarker + " 1 known-issue test(s) failed\n"
-		// http.ServeContent honours the Range header the same way GCS does.
-		http.ServeContent(w, r, "build-log.txt", time.Time{}, strings.NewReader(log))
-	}))
-	defer server.Close()
+func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
+	// A finished.json far larger than any real one should still be read (up to
+	// the cap) without hanging or OOMing, and simply fail to parse as JSON
+	// once truncated - proving the size cap is actually enforced.
+	huge := `{"metadata":{"padding":"` + strings.Repeat("x", maxFinishedJSONBytes+1024) + `","ev2-retry-allowed":true}}`
 
-	got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !got {
-		t.Fatal("expected the marker at the end of a large log to be found, it was not")
-	}
-}
-
-func TestFetchLogContainsEV2RetryMarkerScansWholeLogWhenRangeIgnored(t *testing.T) {
-	// GCS honours Range, but if a server ignores it and returns the whole log
-	// with 200 we still have to find a marker sitting past maxBuildLogBytes.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(strings.Repeat("x", maxBuildLogBytes+1024)))
-		_, _ = w.Write([]byte("\n" + ev2RetryMarker + " 1 known-issue test(s) failed\n"))
+		_, _ = w.Write([]byte(huge))
 	}))
-	defer server.Close()
+	defer srv.Close()
 
-	got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !got {
-		t.Fatal("expected the marker to be found when the server ignores Range, it was not")
-	}
-}
-
-func TestStreamContainsMarkerAcrossChunkBoundary(t *testing.T) {
-	// Split the marker so it straddles the internal chunk boundary, which is
-	// what the carried-over overlap exists to handle.
-	const chunkSize = 64 << 10
-	for _, split := range []int{1, len(ev2RetryMarker) / 2, len(ev2RetryMarker) - 1} {
-		padding := chunkSize - split
-		body := strings.Repeat("x", padding) + ev2RetryMarker + "rest"
-		got, err := streamContainsMarker(strings.NewReader(body))
-		if err != nil {
-			t.Fatalf("split %d: unexpected error: %v", split, err)
-		}
-		if !got {
-			t.Fatalf("split %d: expected the marker straddling a chunk boundary to be found", split)
-		}
-	}
-
-	got, err := streamContainsMarker(strings.NewReader(strings.Repeat("x", 3*chunkSize)))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got {
-		t.Fatal("expected no marker in a log that does not contain one")
+	_, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL)
+	if err == nil {
+		t.Fatal("expected an error from truncated/invalid JSON, got nil")
 	}
 }

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -78,21 +78,39 @@ func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "metadata key true",
+			name:       "single allow-retry failure qualifies",
 			statusCode: http.StatusOK,
-			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":true,"pod":"abc"}}`,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A"],"ev2-allow-retry-tests":["spec A"],"pod":"abc"}}`,
 			want:       true,
 		},
 		{
-			name:       "metadata key absent",
+			name:       "failures at the cap still qualify",
 			statusCode: http.StatusOK,
-			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"pod":"abc"}}`,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B"],"ev2-allow-retry-tests":["spec A","spec B"]}}`,
+			want:       true,
+		},
+		{
+			name:       "one failure over the cap disqualifies",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B","spec C"],"ev2-allow-retry-tests":["spec A","spec B","spec C"]}}`,
 			want:       false,
 		},
 		{
-			name:       "metadata key false",
+			name:       "an unlabeled failure disqualifies the whole run",
 			statusCode: http.StatusOK,
-			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":false}}`,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B"],"ev2-allow-retry-tests":["spec A"]}}`,
+			want:       false,
+		},
+		{
+			name:       "metadata keys absent means no failures reported",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":true,"result":"SUCCESS","metadata":{"pod":"abc"}}`,
+			want:       false,
+		},
+		{
+			name:       "empty failed-tests list is a clean run",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":true,"result":"SUCCESS","metadata":{"ev2-failed-tests":[],"ev2-allow-retry-tests":[]}}`,
 			want:       false,
 		},
 		{
@@ -104,7 +122,7 @@ func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 		{
 			name:       "metadata key wrong type is treated as absent",
 			statusCode: http.StatusOK,
-			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-retry-allowed":"true"}}`,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":"spec A"}}`,
 			want:       false,
 		},
 		{
@@ -129,7 +147,7 @@ func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			got, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL)
+			got, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL, DefaultMaxEV2AutoRetryFailures)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got %v", got)
@@ -150,7 +168,7 @@ func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
 	// A finished.json far larger than any real one should still be read (up to
 	// the cap) without hanging or OOMing, and simply fail to parse as JSON
 	// once truncated - proving the size cap is actually enforced.
-	huge := `{"metadata":{"padding":"` + strings.Repeat("x", maxFinishedJSONBytes+1024) + `","ev2-retry-allowed":true}}`
+	huge := `{"metadata":{"padding":"` + strings.Repeat("x", maxFinishedJSONBytes+1024) + `","ev2-failed-tests":["spec A"]}}`
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -158,8 +176,72 @@ func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL)
+	_, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL, DefaultMaxEV2AutoRetryFailures)
 	if err == nil {
 		t.Fatal("expected an error from truncated/invalid JSON, got nil")
+	}
+}
+
+func TestEV2RetryEligible(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		failed     []string
+		allowRetry []string
+		maxFailure int
+		want       bool
+	}{
+		{
+			name:       "clean run does not qualify",
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "single labeled failure qualifies",
+			failed:     []string{"spec A"},
+			allowRetry: []string{"spec A"},
+			maxFailure: 2,
+			want:       true,
+		},
+		{
+			name:       "failures at the cap still qualify",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A", "spec B"},
+			maxFailure: 2,
+			want:       true,
+		},
+		{
+			name:       "one failure over the cap disqualifies",
+			failed:     []string{"spec A", "spec B", "spec C"},
+			allowRetry: []string{"spec A", "spec B", "spec C"},
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "an unlabeled failure disqualifies the whole run",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A"},
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "a lone unlabeled failure disqualifies",
+			failed:     []string{"spec A"},
+			allowRetry: nil,
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "a lower configured cap tightens eligibility",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A", "spec B"},
+			maxFailure: 1,
+			want:       false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ev2RetryEligible(tc.failed, tc.allowRetry, tc.maxFailure); got != tc.want {
+				t.Fatalf("ev2RetryEligible(%v, %v, %d) = %v, want %v", tc.failed, tc.allowRetry, tc.maxFailure, got, tc.want)
+			}
+		})
 	}
 }

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildLogURLFromViewURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		viewURL string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "typical prow deck view URL",
+			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345/build-log.txt",
+		},
+		{
+			name:    "trailing slash is trimmed",
+			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/some-job/1/",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/some-job/1/build-log.txt",
+		},
+		{
+			name:    "empty URL",
+			viewURL: "",
+			wantErr: true,
+		},
+		{
+			name:    "missing /view/gs/ prefix",
+			viewURL: "https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/some-job",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildLogURLFromViewURL(tt.viewURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got url %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchLogContainsEV2RetryMarker(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "marker present",
+			body:       "some test output\nEV2_RETRY_ALLOWED: 1 known-issue test(s) failed (max 2 allowed), all labeled \"allow-retry\": [\"foo\"]\nmore output",
+			statusCode: http.StatusOK,
+			want:       true,
+		},
+		{
+			name:       "marker absent",
+			body:       "some test output\nsome other failure\nmore output",
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "non-200 status",
+			body:       "not found",
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchLogContainsEV2RetryMarkerTruncatesLargeLogs(t *testing.T) {
+	// The marker appears only past maxBuildLogBytes; the reader should stop
+	// before reaching it and report false, not an error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxBuildLogBytes+1024)))
+		_, _ = w.Write([]byte(ev2RetryMarker))
+	}))
+	defer server.Close()
+
+	got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatalf("expected marker beyond the read cap to be ignored, but it was found")
+	}
+}

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildLogURLFromViewURL(t *testing.T) {
@@ -122,13 +123,14 @@ func TestFetchLogContainsEV2RetryMarker(t *testing.T) {
 	}
 }
 
-func TestFetchLogContainsEV2RetryMarkerTruncatesLargeLogs(t *testing.T) {
-	// The marker appears only past maxBuildLogBytes; the reader should stop
-	// before reaching it and report false, not an error.
+func TestFetchLogContainsEV2RetryMarkerFindsMarkerAtEndOfLargeLog(t *testing.T) {
+	// The marker is printed from an AfterAll, so on a real E2E run it sits at
+	// the very end of a log far larger than maxBuildLogBytes. Reading from the
+	// front would miss it, which would silently disable the whole retry path.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(strings.Repeat("x", maxBuildLogBytes+1024)))
-		_, _ = w.Write([]byte(ev2RetryMarker))
+		log := strings.Repeat("x", maxBuildLogBytes+1024) + "\n" + ev2RetryMarker + " 1 known-issue test(s) failed\n"
+		// http.ServeContent honours the Range header the same way GCS does.
+		http.ServeContent(w, r, "build-log.txt", time.Time{}, strings.NewReader(log))
 	}))
 	defer server.Close()
 
@@ -136,7 +138,51 @@ func TestFetchLogContainsEV2RetryMarkerTruncatesLargeLogs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !got {
+		t.Fatal("expected the marker at the end of a large log to be found, it was not")
+	}
+}
+
+func TestFetchLogContainsEV2RetryMarkerScansWholeLogWhenRangeIgnored(t *testing.T) {
+	// GCS honours Range, but if a server ignores it and returns the whole log
+	// with 200 we still have to find a marker sitting past maxBuildLogBytes.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxBuildLogBytes+1024)))
+		_, _ = w.Write([]byte("\n" + ev2RetryMarker + " 1 known-issue test(s) failed\n"))
+	}))
+	defer server.Close()
+
+	got, err := fetchLogContainsEV2RetryMarker(testContext(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatal("expected the marker to be found when the server ignores Range, it was not")
+	}
+}
+
+func TestStreamContainsMarkerAcrossChunkBoundary(t *testing.T) {
+	// Split the marker so it straddles the internal chunk boundary, which is
+	// what the carried-over overlap exists to handle.
+	const chunkSize = 64 << 10
+	for _, split := range []int{1, len(ev2RetryMarker) / 2, len(ev2RetryMarker) - 1} {
+		padding := chunkSize - split
+		body := strings.Repeat("x", padding) + ev2RetryMarker + "rest"
+		got, err := streamContainsMarker(strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("split %d: unexpected error: %v", split, err)
+		}
+		if !got {
+			t.Fatalf("split %d: expected the marker straddling a chunk boundary to be found", split)
+		}
+	}
+
+	got, err := streamContainsMarker(strings.NewReader(strings.Repeat("x", 3*chunkSize)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if got {
-		t.Fatalf("expected marker beyond the read cap to be ignored, but it was found")
+		t.Fatal("expected no marker in a log that does not contain one")
 	}
 }


### PR DESCRIPTION
Jira: [AROSLSRE-1721](https://redhat.atlassian.net/browse/AROSLSRE-1721)

### What

Add an EV2 auto-retry to `prow-job-executor`'s gating path. When a gated job fails and its `finished.json` metadata shows only known, deliberately-labeled tests failed (up to a small cap), the executor resubmits the job exactly once before failing the gate.

### Why

Right now, when a small number of E2E tests fail on a known, already-tracked issue during an EV2 Stage/Prod gating step, a human has to notice the failure, open the Prow output, and manually retrigger the rollout (for Stage) or click retry in the saw (for Prod). That adds latency and churn to every rollout for a failure class that's already understood and safe to retry.

```text
ARO-HCP test run
  -> a test fails
  -> test is labeled allow-retry (known, tracked issue)?
       yes -> aro-hcp-tests writes failed + allow-retry test names
              to $ARTIFACT_DIR/metadata.json (Azure/ARO-HCP#6409)
       no  -> nothing written, gate fails normally
  -> Prow sidecar merges metadata.json into finished.json
  -> prow-job-executor (this PR) reads finished.json back out
  -> all failures labeled AND count <= cap?
       yes -> resubmit the job once, then gate on that result
       no  -> gate fails normally, human triages
```

[Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) adds the `allow-retry` ginkgo label and writes the raw facts (every failed test name, and the subset labeled `allow-retry`) into `metadata.json`. This PR teaches `prow-job-executor` to read those facts back out of `finished.json` and decide, on its own, whether the failure is narrow enough to retry, keeping the eligibility policy (the cap) here rather than baked into an ARO-HCP release.

Prow's `result` field (`SUCCESS`/`FAILURE`/`ABORTED`) is hardcoded by the sidecar from the container exit code, so a custom result value isn't possible. An earlier version of this PR grepped a marker line out of `build-log.txt` instead, but that's fragile (truncation risk, no structure, needs a tail-range fetch). `metadata.json` is Prow's own supported mechanism for a step to attach structured data to `finished.json`, so that's what this now uses.

### What changes

```text
Monitor.ExecuteAndWait
  -> executeAndWaitOnce (submit + poll, unchanged)
  -> job fails with a real test failure (JobFailedError, not infra/abort)?
       no  -> return the error as-is
       yes -> allowEV2Retry set?
                no  -> return the error as-is
                yes -> checkRetryMarker: fetch finished.json, apply cap
                         -> eligible  -> retry once (allowEV2Retry forced off
                                          on the retry, so it can't recurse)
                         -> not eligible or fetch failed -> return original error
```

- `prowjob.Monitor` gains an `allowEV2Retry` flag and a `JobFailedError` type that distinguishes real test failures (`FailureState`) from infra errors/aborts, which are never auto-retried.
- `prowjob/retrymarker.go` converts a Prow view URL into its GCS `finished.json` URL, fetches it (size-capped), and reads the `ev2-failed-tests` / `ev2-allow-retry-tests` metadata lists. `ev2RetryEligible` (kept separate from the fetch/parse so it's independently testable) qualifies a run only when it failed at all, no more than `maxAutoRetryFailures` tests failed, and every failed test is in the allow-retry list.
- `ExecuteAndWait` checks that signal on `JobFailedError` and retries once via a shallow copy of the `Monitor` with `allowEV2Retry` disabled, so it can never retry more than once. The whole retry, including the extra fetch and resubmission, still has to fit inside the original `--timeout`.
- `--allow-ev2-retry` CLI flag (execute path only) plus `--max-ev2-auto-retry-failures` (default `2`, tunable without an ARO-HCP rebuild). The read-only `monitor` subcommand always passes `allowEV2Retry=false` since it can't meaningfully resubmit.

### Example

```
--allow-ev2-retry --max-ev2-auto-retry-failures=2

finished.json metadata:
  ev2-failed-tests:      ["ClusterCreation should retry on X"]
  ev2-allow-retry-tests: ["ClusterCreation should retry on X"]

-> 1 failure, labeled, within cap -> eligible -> job resubmitted once
```

```
finished.json metadata:
  ev2-failed-tests:      ["A", "B", "C"]
  ev2-allow-retry-tests: ["A", "B", "C"]

-> 3 failures > cap (2) -> not eligible -> gate fails normally
```

### Validation

```
go build ./...
go vet ./...
go test -race -count=1 ./...
go tool golangci-lint run ./...
gofmt -l .
```

All pass in `tools/prow-job-executor`. Unit tests cover the `finished.json` URL conversion, the metadata fetch/parse (key true/false/absent/wrong-type, non-200, invalid JSON, oversized body), the `ev2RetryEligible` cap/labeling matrix, and the full `Monitor.ExecuteAndWait` retry flow (retries once when eligible, does not retry when not eligible, never retries twice, and skips the check entirely when `allowEV2Retry` is false).

### Follow-ups

- The actual EV2 pipeline step definitions that pass `--allow-ev2-retry` and `--max-ev2-auto-retry-failures` still need to be wired up (likely in `sdp-pipelines` or the `openshift/release` step registry), tracked separately under AROSLSRE-1721.
