### PR TITLE
Make SafeFly an entrypoint opt-in rather than an authored step

### DIFF
--- a/pipelines/testdata/pipeline.yaml
+++ b/pipelines/testdata/pipeline.yaml
@@ -519,10 +519,6 @@ resourceGroups:
         resourceGroup: regional
         step: deploy
         name: whatever
-    - name: safefly-submit
-      action: SafeFly
-      shellIdentity:
-        configRef: aroDevopsMsiId
   validationSteps:
   - name: e2e
     action: ProwJob

--- a/pipelines/topology/types.go
+++ b/pipelines/topology/types.go
@@ -56,6 +56,9 @@ type Entrypoint struct {
 	// Identifier is the root of the sub-tree selected by this entrypoint.
 	Identifier string `json:"identifier"`
 
+	// SafeFly opts this sub-tree into generated SafeFly request submission.
+	SafeFly bool `json:"safeFly,omitempty"`
+
 	// Metadata is an extension point to store useful information for the sub-tree.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/pipelines/topology/types_test.go
+++ b/pipelines/topology/types_test.go
@@ -554,6 +554,30 @@ func TestLoad_PropagateStamped(t *testing.T) {
 	}
 }
 
+func TestLoad_EntrypointSafeFly(t *testing.T) {
+	path := writeTempTopology(t, `entrypoints:
+- identifier: opted-in
+  safeFly: true
+- identifier: default
+services:
+- serviceGroup: opted-in
+- serviceGroup: default`)
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []Entrypoint{
+		{Identifier: "opted-in", SafeFly: true},
+		{Identifier: "default"},
+	}
+
+	if diff := cmp.Diff(expected, got.Entrypoints); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestLoadCombined_TopologyDirMapping(t *testing.T) {
 	teamAPath := filepath.Join("testdata", "team-a", "topology.yaml")
 	teamBPath := filepath.Join("testdata", "team-b", "topology.yaml")

--- a/pipelines/types/pipeline.schema.v1.json
+++ b/pipelines/types/pipeline.schema.v1.json
@@ -468,27 +468,6 @@
         }
       ]
     },
-    "safeFlyStep": {
-      "unevaluatedProperties": false,
-      "allOf": [
-        {
-          "$ref": "#/definitions/stepMeta"
-        },
-        {
-          "properties": {
-            "action": {
-              "const": "SafeFly"
-            },
-            "shellIdentity": {
-              "$ref": "#/definitions/value"
-            }
-          },
-          "required": [
-            "shellIdentity"
-          ]
-        }
-      ]
-    },
     "shellValidationStep": {
       "unevaluatedProperties": false,
       "allOf": [
@@ -1831,22 +1810,6 @@
                     "type": "object",
                     "properties": {
                       "action": {
-                        "const": "SafeFly"
-                      }
-                    },
-                    "required": [
-                      "action"
-                    ]
-                  },
-                  "then": {
-                    "$ref": "#/definitions/safeFlyStep"
-                  }
-                },
-                {
-                  "if": {
-                    "type": "object",
-                    "properties": {
-                      "action": {
                         "const": "Helm"
                       }
                     },
@@ -2214,6 +2177,18 @@
                   }
                 }
               ],
+              "not": {
+                "description": "SafeFly steps are generated from an entrypoint opt-in, not authored.",
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "const": "SafeFly"
+                  }
+                },
+                "required": [
+                  "action"
+                ]
+              },
               "required": [
                 "name",
                 "action"

--- a/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
+++ b/pipelines/types/testdata/zz_fixture_TestNewPipelineFromFile.yaml
@@ -538,10 +538,6 @@ resourceGroups:
       resourceGroup: regional
       step: deploy
     name: datasources
-  - action: SafeFly
-    name: safefly-submit
-    shellIdentity:
-      configRef: aroDevopsMsiId
   subscription: hcp-uksouth
   subscriptionProvisioning:
     displayName:

--- a/pipelines/types/validation_test.go
+++ b/pipelines/types/validation_test.go
@@ -338,7 +338,7 @@ func TestValidatePipelineSchema(t *testing.T) {
 			},
 		},
 		{
-			name: "valid safefly",
+			name: "safefly is not authorable",
 			pipeline: map[string]interface{}{
 				"serviceGroup": "test",
 				"rolloutName":  "test",
@@ -354,26 +354,6 @@ func TestValidatePipelineSchema(t *testing.T) {
 								"shellIdentity": map[string]interface{}{
 									"configRef": "safeFlyMsiId",
 								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "invalid safefly missing shell identity",
-			pipeline: map[string]interface{}{
-				"serviceGroup": "test",
-				"rolloutName":  "test",
-				"resourceGroups": []interface{}{
-					map[string]interface{}{
-						"name":          "rg",
-						"resourceGroup": "rg",
-						"subscription":  "sub",
-						"steps": []interface{}{
-							map[string]interface{}{
-								"name":   "step",
-								"action": "SafeFly",
 							},
 						},
 					},


### PR DESCRIPTION
## What

Moves the SafeFly opt-in from an authored pipeline step to a typed field on `Entrypoint`, and makes SafeFly step non-authorable.

## Why

There was no benefit from exposing the step to the users. The previous shape let the author set the identity, the placement, and a dependency set that all had exactly one correct value, so there wasn't much value in exposing it. Making it a rollout-level opt-in lets the generator own the placement, the identity, and the dependencies and execution constraints.

## Testing

- `go test ./types` passes.