### PR TITLE
feat(prow-job-executor): read the retry signal from finished.json metadata (AROSLSRE-1721)

### DIFF
--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -54,17 +54,18 @@ const (
 
 func DefaultExecuteOptions() *RawExecuteOptions {
 	return &RawExecuteOptions{
-		RawProwTokenOptions: NewDefaultRawProwTokenOptions(),
-		Labels:              make(map[string]string),
-		Annotations:         make(map[string]string),
-		EnvironmentVars:     make(map[string]string),
-		PollInterval:        300 * time.Second,
-		Timeout:             4 * time.Hour,
-		GangwayURL:          defaultGangwayURL,
-		ProwURL:             defaultProwURL,
-		BaseRef:             defaultBaseRef,
-		Org:                 defaultOrg,
-		Repo:                defaultRepo,
+		RawProwTokenOptions:     NewDefaultRawProwTokenOptions(),
+		Labels:                  make(map[string]string),
+		Annotations:             make(map[string]string),
+		EnvironmentVars:         make(map[string]string),
+		PollInterval:            300 * time.Second,
+		Timeout:                 4 * time.Hour,
+		GangwayURL:              defaultGangwayURL,
+		ProwURL:                 defaultProwURL,
+		BaseRef:                 defaultBaseRef,
+		Org:                     defaultOrg,
+		Repo:                    defaultRepo,
+		MaxEV2AutoRetryFailures: prowjob.DefaultMaxEV2AutoRetryFailures,
 	}
 }
 
@@ -84,6 +85,8 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&o.ProwURL, "prow-url", o.ProwURL, "Prow API URL for job status monitoring")
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print which job would be started, but do not start one.")
 	cmd.Flags().BoolVar(&o.GatePromotion, "gate-promotion", o.GatePromotion, "Exit with an error code if the job fails.")
+	cmd.Flags().BoolVar(&o.AllowEV2Retry, "allow-ev2-retry", o.AllowEV2Retry, "When gate-promotion is set and the job fails, fail with a distinct, matchable error if its finished.json metadata marks the failure as narrow enough to safely retry, so the gating step's EV2 automatedRetry re-runs the whole step. Does not resubmit the job itself.")
+	cmd.Flags().IntVar(&o.MaxEV2AutoRetryFailures, "max-ev2-auto-retry-failures", o.MaxEV2AutoRetryFailures, "Maximum number of failed tests (all labeled allow-retry) a job may have and still qualify for an automatic EV2 gating retry. Has no effect unless allow-ev2-retry is set.")
 	cmd.Flags().StringVar(&o.BaseSha, "base-sha", o.BaseSha, "Git commit SHA to test against. When set, the job is triggered as a postsubmit with this specific commit instead of HEAD.")
 	cmd.Flags().StringVar(&o.BaseRef, "base-ref", o.BaseRef, "Git base ref (branch) for the postsubmit job (requires --base-sha)")
 	cmd.Flags().StringVar(&o.Org, "org", o.Org, "GitHub org for the postsubmit job (requires --base-sha)")
@@ -108,21 +111,23 @@ func (o *RawExecuteOptions) BindFlags(cmd *cobra.Command) error {
 type RawExecuteOptions struct {
 	*RawProwTokenOptions
 
-	Cloud                string
-	Environment          string
-	Region               string
-	AllowedSubscriptions string
-	ProwJobName          string
-	Labels               map[string]string
-	Annotations          map[string]string
-	EnvironmentVars      map[string]string
-	EV2RolloutVersion    string
-	PollInterval         time.Duration
-	Timeout              time.Duration
-	GangwayURL           string
-	ProwURL              string
-	DryRun               bool
-	GatePromotion        bool
+	Cloud                   string
+	Environment             string
+	Region                  string
+	AllowedSubscriptions    string
+	ProwJobName             string
+	Labels                  map[string]string
+	Annotations             map[string]string
+	EnvironmentVars         map[string]string
+	EV2RolloutVersion       string
+	PollInterval            time.Duration
+	Timeout                 time.Duration
+	GangwayURL              string
+	ProwURL                 string
+	DryRun                  bool
+	GatePromotion           bool
+	AllowEV2Retry           bool
+	MaxEV2AutoRetryFailures int
 
 	// Git ref options for postsubmit execution pinned to a specific commit.
 	// When BaseSha is set, the job is triggered as a postsubmit instead of a periodic.
@@ -148,21 +153,23 @@ type ValidatedExecuteOptions struct {
 
 // completedExecuteOptions is a private wrapper that enforces a call of Complete() before execution can be invoked.
 type completedExecuteOptions struct {
-	Cloud                string
-	Environment          string
-	Region               string
-	AllowedSubscriptions string
-	ProwJobName          string
-	Labels               map[string]string
-	Annotations          map[string]string
-	EnvironmentVars      map[string]string
-	PollInterval         time.Duration
-	Timeout              time.Duration
-	ProwToken            string
-	GangwayURL           string
-	ProwURL              string
-	DryRun               bool
-	GatePromotion        bool
+	Cloud                   string
+	Environment             string
+	Region                  string
+	AllowedSubscriptions    string
+	ProwJobName             string
+	Labels                  map[string]string
+	Annotations             map[string]string
+	EnvironmentVars         map[string]string
+	PollInterval            time.Duration
+	Timeout                 time.Duration
+	ProwToken               string
+	GangwayURL              string
+	ProwURL                 string
+	DryRun                  bool
+	GatePromotion           bool
+	AllowEV2Retry           bool
+	MaxEV2AutoRetryFailures int
 
 	// Git ref options for postsubmit execution
 	BaseSha string
@@ -261,6 +268,10 @@ func (o *RawExecuteOptions) Validate(ctx context.Context) (*ValidatedExecuteOpti
 		return nil, fmt.Errorf("timeout must be greater than 0")
 	}
 
+	if o.AllowEV2Retry && o.MaxEV2AutoRetryFailures <= 0 {
+		return nil, fmt.Errorf("max-ev2-auto-retry-failures must be greater than 0 when allow-ev2-retry is set")
+	}
+
 	return &ValidatedExecuteOptions{
 		validatedExecuteOptions: &validatedExecuteOptions{
 			RawExecuteOptions:         o,
@@ -280,25 +291,27 @@ func (o *ValidatedExecuteOptions) Complete(ctx context.Context) (*ExecuteOptions
 
 	return &ExecuteOptions{
 		completedExecuteOptions: &completedExecuteOptions{
-			Cloud:                o.Cloud,
-			Environment:          o.Environment,
-			Region:               o.Region,
-			AllowedSubscriptions: o.AllowedSubscriptions,
-			ProwJobName:          o.ProwJobName,
-			Labels:               o.ParsedLabels,
-			Annotations:          o.ParsedAnnotations,
-			EnvironmentVars:      o.ParsedEnvironmentVars,
-			PollInterval:         o.PollInterval,
-			Timeout:              o.Timeout,
-			ProwToken:            completed.ProwToken,
-			GangwayURL:           o.GangwayURL,
-			ProwURL:              o.ProwURL,
-			DryRun:               o.DryRun,
-			GatePromotion:        o.GatePromotion,
-			BaseSha:              o.BaseSha,
-			BaseRef:              o.BaseRef,
-			Org:                  o.Org,
-			Repo:                 o.Repo,
+			Cloud:                   o.Cloud,
+			Environment:             o.Environment,
+			Region:                  o.Region,
+			AllowedSubscriptions:    o.AllowedSubscriptions,
+			ProwJobName:             o.ProwJobName,
+			Labels:                  o.ParsedLabels,
+			Annotations:             o.ParsedAnnotations,
+			EnvironmentVars:         o.ParsedEnvironmentVars,
+			PollInterval:            o.PollInterval,
+			Timeout:                 o.Timeout,
+			ProwToken:               completed.ProwToken,
+			GangwayURL:              o.GangwayURL,
+			ProwURL:                 o.ProwURL,
+			DryRun:                  o.DryRun,
+			GatePromotion:           o.GatePromotion,
+			AllowEV2Retry:           o.AllowEV2Retry,
+			MaxEV2AutoRetryFailures: o.MaxEV2AutoRetryFailures,
+			BaseSha:                 o.BaseSha,
+			BaseRef:                 o.BaseRef,
+			Org:                     o.Org,
+			Repo:                    o.Repo,
 		},
 	}, nil
 }
@@ -313,7 +326,7 @@ func (o *ExecuteOptions) Execute(ctx context.Context) error {
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
 
 	// Create job monitor
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, o.DryRun, o.GatePromotion, o.AllowEV2Retry, o.MaxEV2AutoRetryFailures)
 
 	// Prepare environment variables, including the region
 	envs := make(map[string]string)
@@ -516,7 +529,7 @@ func (o *ValidatedMonitorOptions) Complete(ctx context.Context) (*MonitorOptions
 func (o *MonitorOptions) Monitor(ctx context.Context, logger logr.Logger) error {
 	// Create Prow client and monitor
 	client := prowjob.NewClient(o.ProwToken, o.GangwayURL, o.ProwURL)
-	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false)
+	monitor := prowjob.NewMonitor(client, o.PollInterval, o.Timeout, false, false, false, prowjob.DefaultMaxEV2AutoRetryFailures)
 
 	// Monitor existing job using shared polling logic
 	logger.Info("Starting to monitor existing job", "jobExecutionID", o.JobExecutionID)

--- a/tools/prow-job-executor/options.go
+++ b/tools/prow-job-executor/options.go
@@ -268,6 +268,10 @@ func (o *RawExecuteOptions) Validate(ctx context.Context) (*ValidatedExecuteOpti
 		return nil, fmt.Errorf("timeout must be greater than 0")
 	}
 
+	if o.AllowEV2Retry && !o.GatePromotion {
+		return nil, fmt.Errorf("gate-promotion must be set when allow-ev2-retry is set")
+	}
+
 	if o.AllowEV2Retry && o.MaxEV2AutoRetryFailures <= 0 {
 		return nil, fmt.Errorf("max-ev2-auto-retry-failures must be greater than 0 when allow-ev2-retry is set")
 	}

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -16,6 +16,7 @@ package prowjob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,23 +26,80 @@ import (
 	prowgangway "sigs.k8s.io/prow/pkg/gangway"
 )
 
+// JobFailedError indicates a Prow job completed in the "failure" state - as
+// opposed to "error" or "aborted", which usually indicate an infra problem or
+// a cancellation rather than a test failure. Timeouts are reported separately
+// as plain errors, not as JobFailedError. Only jobs that failed this way are
+// candidates for the EV2 auto-retry, since that's the class of failure the
+// allow-retry test label and finished.json retry metadata are about (see
+// AROSLSRE-1721).
+type JobFailedError struct {
+	ProwExecutionID string
+	JobURL          string
+}
+
+func (e *JobFailedError) Error() string {
+	return fmt.Sprintf("job %s failed - check the Prow UI for detailed logs: %s", e.ProwExecutionID, e.JobURL)
+}
+
+// EV2RetryableMarker is the fixed, matchable substring prow-job-executor emits when a
+// gating job failure is eligible for an automatic EV2 retry (see ev2RetryEligible). The
+// EV2 gating step's pipeline.yaml configures automatedRetry.errorContainsAny with this
+// marker, so EV2 - not prow-job-executor - re-runs the whole step from scratch when it
+// sees the marker in the step's captured error output. prow-job-executor never resubmits
+// the job itself; it only decides whether the failure qualifies and surfaces that
+// decision through the error text.
+const EV2RetryableMarker = "ev2-retryable-known-issue-failure"
+
+// EV2RetryableError wraps a job failure that finished.json's metadata marks as safe to
+// auto-retry. Its Error() text always contains EV2RetryableMarker, so EV2's
+// automatedRetry.errorContainsAny can match on it and re-run the gating step.
+type EV2RetryableError struct {
+	Cause error
+}
+
+func (e *EV2RetryableError) Error() string {
+	return fmt.Sprintf("%s: %s", EV2RetryableMarker, e.Cause.Error())
+}
+
+func (e *EV2RetryableError) Unwrap() error {
+	return e.Cause
+}
+
 // Monitor handles job execution and monitoring
 type Monitor struct {
-	client        *Client
-	pollInterval  time.Duration
-	timeout       time.Duration
-	dryRun        bool
-	gatePromotion bool
+	client               *Client
+	pollInterval         time.Duration
+	timeout              time.Duration
+	dryRun               bool
+	gatePromotion        bool
+	allowEV2Retry        bool
+	maxAutoRetryFailures int
+
+	// checkRetryMarker fetches finished.json for a job's status URL and reports
+	// whether its metadata marks the run as safe to auto-retry. Defaults to
+	// jobAllowsEV2Retry; overridable in tests.
+	checkRetryMarker func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error)
 }
 
 // NewMonitor creates a new job monitor with the specified polling interval and timeout.
-func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion bool) *Monitor {
+// allowEV2Retry opts into checking a failed job's finished.json metadata and, if it marks
+// the failure as safe to retry (see AROSLSRE-1721), failing with EV2RetryableError instead
+// of a plain JobFailedError - so the EV2 gating step's automatedRetry re-runs the whole
+// step, rather than prow-job-executor resubmitting the job itself. It has no effect unless
+// gatePromotion is also true. maxAutoRetryFailures caps how many failed tests a run may
+// have (all labeled allow-retry) and still qualify; pass DefaultMaxEV2AutoRetryFailures
+// unless a caller wants to tune it without an ARO-HCP rebuild.
+func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gatePromotion, allowEV2Retry bool, maxAutoRetryFailures int) *Monitor {
 	return &Monitor{
-		client:        client,
-		pollInterval:  pollInterval,
-		timeout:       timeout,
-		dryRun:        dryRun,
-		gatePromotion: gatePromotion,
+		client:               client,
+		pollInterval:         pollInterval,
+		timeout:              timeout,
+		dryRun:               dryRun,
+		gatePromotion:        gatePromotion,
+		allowEV2Retry:        allowEV2Retry,
+		maxAutoRetryFailures: maxAutoRetryFailures,
+		checkRetryMarker:     jobAllowsEV2Retry,
 	}
 }
 
@@ -75,9 +133,9 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 				return nil
 			case string(prowjobs.FailureState):
 				if m.gatePromotion {
-					return fmt.Errorf("job %s failed - check the Prow UI for detailed logs: %s", prowExecutionID, job.Status.URL)
+					return &JobFailedError{ProwExecutionID: prowExecutionID, JobURL: job.Status.URL}
 				} else {
-					logger.Error(err, "Unexpected job state, but gating is not requested.")
+					logger.Info("Unexpected job state, but gating is not requested.")
 					return nil
 				}
 			case string(prowjobs.ErrorState):
@@ -109,8 +167,17 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 	}
 }
 
-// ExecuteAndWait submits a job and waits for completion
+// ExecuteAndWait submits a job once and waits for completion. It never resubmits the job
+// itself. If the job fails (JobFailedError) and this Monitor has allowEV2Retry set, it
+// fetches the failed job's finished.json and, if its metadata marks it as safe to retry
+// (only known-issue tests failed, see AROSLSRE-1721), returns an EV2RetryableError instead
+// of the plain JobFailedError. The EV2 gating step's pipeline.yaml matches
+// EV2RetryableMarker via automatedRetry.errorContainsAny and re-runs the whole step from
+// scratch - prow-job-executor only decides eligibility, EV2 owns the actual retry.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
 	// Submit job
 	logger.Info("Submitting Prow job", "jobName", request.JobName)
 	if m.dryRun {
@@ -124,6 +191,25 @@ func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, reques
 
 	logger.Info("Job submitted successfully", "prowExecutionID", prowExecutionID, "jobName", request.JobName)
 
-	// Wait for completion using shared logic
-	return m.WaitForCompletion(ctx, logger, prowExecutionID)
+	err = m.WaitForCompletion(ctx, logger, prowExecutionID)
+	if err == nil || !m.allowEV2Retry {
+		return err
+	}
+
+	var failedErr *JobFailedError
+	if !errors.As(err, &failedErr) {
+		return err
+	}
+
+	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL, m.maxAutoRetryFailures)
+	if checkErr != nil {
+		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, failing normally", "prowExecutionID", failedErr.ProwExecutionID)
+		return err
+	}
+	if !retry {
+		return err
+	}
+
+	logger.Info("finished.json marks the run as safe to retry, failing with the EV2-retryable marker so the gating step's automatedRetry re-runs it", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
+	return &EV2RetryableError{Cause: err}
 }

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -142,14 +142,14 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 				if m.gatePromotion {
 					return fmt.Errorf("job %s encountered an error - check Prow status page and job logs for details: %s", prowExecutionID, job.Status.URL)
 				} else {
-					logger.Error(err, "Unexpected job state, but gating is not requested.")
+					logger.Info("Unexpected job state, but gating is not requested.")
 					return nil
 				}
 			case string(prowjobs.AbortedState):
 				if m.gatePromotion {
 					return fmt.Errorf("job %s was aborted - this may be due to timeout or manual cancellation", prowExecutionID)
 				} else {
-					logger.Error(err, "Unexpected job state, but gating is not requested.")
+					logger.Info("Unexpected job state, but gating is not requested.")
 					return nil
 				}
 			}
@@ -175,8 +175,9 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 // EV2RetryableMarker via automatedRetry.errorContainsAny and re-runs the whole step from
 // scratch - prow-job-executor only decides eligibility, EV2 owns the actual retry.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
-	ctx, cancel := context.WithTimeout(ctx, m.timeout)
-	defer cancel()
+	// WaitForCompletion applies m.timeout itself; don't apply it again here too, since a
+	// child context can't outlive its parent - doing so would start the whole monitoring
+	// window early, before the job is even submitted.
 
 	// Submit job
 	logger.Info("Submitting Prow job", "jobName", request.JobName)

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -113,8 +113,10 @@ type JobOutcome struct {
 	// Retryable is true only when Err is non-nil and came from the job finishing in the
 	// "failure" state - the class of failure the EV2 auto-retry (AROSLSRE-1721) applies to.
 	Retryable bool
-	// JobURL is the Prow status page URL, populated whenever the job's status was
-	// successfully observed at least once (even on failure/error/timeout).
+	// JobURL is the Prow status page URL. It's only populated when Err is non-nil and
+	// gating was requested (FailureState/ErrorState/AbortedState with m.gatePromotion set,
+	// or a timeout after a status was observed) - it's empty on success and on the
+	// non-gating "unexpected status" paths, since there's no failure to report there.
 	JobURL string
 }
 

--- a/tools/prow-job-executor/prowjob/monitor.go
+++ b/tools/prow-job-executor/prowjob/monitor.go
@@ -16,7 +16,6 @@ package prowjob
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -103,8 +102,31 @@ func NewMonitor(client *Client, pollInterval, timeout time.Duration, dryRun, gat
 	}
 }
 
-// WaitForCompletion polls job status until completion
+// JobOutcome carries the result of waiting for a Prow job, with retry eligibility as an
+// explicit field rather than something callers have to infer by type-asserting Err. Only a
+// job that completed in the "failure" state (as opposed to "error"/"aborted", which usually
+// indicate an infra problem or a cancellation) is ever Retryable; ExecuteAndWait uses this
+// field directly instead of errors.As-ing for *JobFailedError.
+type JobOutcome struct {
+	// Err is nil on success, otherwise the reason WaitForCompletion stopped waiting.
+	Err error
+	// Retryable is true only when Err is non-nil and came from the job finishing in the
+	// "failure" state - the class of failure the EV2 auto-retry (AROSLSRE-1721) applies to.
+	Retryable bool
+	// JobURL is the Prow status page URL, populated whenever the job's status was
+	// successfully observed at least once (even on failure/error/timeout).
+	JobURL string
+}
+
+// WaitForCompletion polls job status until completion.
 func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, prowExecutionID string) error {
+	return m.waitForCompletion(ctx, logger, prowExecutionID).Err
+}
+
+// waitForCompletion is the shared polling implementation. It returns a JobOutcome so callers
+// that need to distinguish a retry-eligible job failure (ExecuteAndWait) can check
+// outcome.Retryable directly, without control flow via typed-error inspection.
+func (m *Monitor) waitForCompletion(ctx context.Context, logger logr.Logger, prowExecutionID string) JobOutcome {
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
@@ -130,27 +152,37 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 			switch status {
 			case string(prowjobs.SuccessState):
 				logger.Info("Job completed successfully")
-				return nil
+				return JobOutcome{}
 			case string(prowjobs.FailureState):
 				if m.gatePromotion {
-					return &JobFailedError{ProwExecutionID: prowExecutionID, JobURL: job.Status.URL}
+					return JobOutcome{
+						Err:       &JobFailedError{ProwExecutionID: prowExecutionID, JobURL: job.Status.URL},
+						Retryable: true,
+						JobURL:    job.Status.URL,
+					}
 				} else {
 					logger.Info("Unexpected job state, but gating is not requested.")
-					return nil
+					return JobOutcome{}
 				}
 			case string(prowjobs.ErrorState):
 				if m.gatePromotion {
-					return fmt.Errorf("job %s encountered an error - check Prow status page and job logs for details: %s", prowExecutionID, job.Status.URL)
+					return JobOutcome{
+						Err:    fmt.Errorf("job %s encountered an error - check Prow status page and job logs for details: %s", prowExecutionID, job.Status.URL),
+						JobURL: job.Status.URL,
+					}
 				} else {
 					logger.Info("Unexpected job state, but gating is not requested.")
-					return nil
+					return JobOutcome{}
 				}
 			case string(prowjobs.AbortedState):
 				if m.gatePromotion {
-					return fmt.Errorf("job %s was aborted - this may be due to timeout or manual cancellation", prowExecutionID)
+					return JobOutcome{
+						Err:    fmt.Errorf("job %s was aborted - this may be due to timeout or manual cancellation", prowExecutionID),
+						JobURL: job.Status.URL,
+					}
 				} else {
 					logger.Info("Unexpected job state, but gating is not requested.")
-					return nil
+					return JobOutcome{}
 				}
 			}
 		}
@@ -158,9 +190,12 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 		select {
 		case <-ctx.Done():
 			if job != nil {
-				return fmt.Errorf("job monitoring timed out after %v - job %s may still be running, check Prow UI: %s", m.timeout, prowExecutionID, job.Status.URL)
+				return JobOutcome{
+					Err:    fmt.Errorf("job monitoring timed out after %v - job %s may still be running, check Prow UI: %s", m.timeout, prowExecutionID, job.Status.URL),
+					JobURL: job.Status.URL,
+				}
 			}
-			return fmt.Errorf("job monitoring timed out after %v - job %s may still be running (unable to retrieve job status)", m.timeout, prowExecutionID)
+			return JobOutcome{Err: fmt.Errorf("job monitoring timed out after %v - job %s may still be running (unable to retrieve job status)", m.timeout, prowExecutionID)}
 		case <-ticker.C:
 			// Continue to next iteration
 		}
@@ -168,12 +203,13 @@ func (m *Monitor) WaitForCompletion(ctx context.Context, logger logr.Logger, pro
 }
 
 // ExecuteAndWait submits a job once and waits for completion. It never resubmits the job
-// itself. If the job fails (JobFailedError) and this Monitor has allowEV2Retry set, it
-// fetches the failed job's finished.json and, if its metadata marks it as safe to retry
-// (only known-issue tests failed, see AROSLSRE-1721), returns an EV2RetryableError instead
-// of the plain JobFailedError. The EV2 gating step's pipeline.yaml matches
-// EV2RetryableMarker via automatedRetry.errorContainsAny and re-runs the whole step from
-// scratch - prow-job-executor only decides eligibility, EV2 owns the actual retry.
+// itself. If the job's JobOutcome comes back Retryable (see JobOutcome) and this Monitor has
+// allowEV2Retry set, it fetches the failed job's finished.json and, if its metadata marks it
+// as safe to retry (only known-issue tests failed, see AROSLSRE-1721), returns an
+// EV2RetryableError instead of the plain job-failure error. The EV2 gating step's
+// pipeline.yaml matches EV2RetryableMarker via automatedRetry.errorContainsAny and re-runs
+// the whole step from scratch - prow-job-executor only decides eligibility, EV2 owns the
+// actual retry.
 func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, request *prowgangway.CreateJobExecutionRequest) error {
 	// WaitForCompletion applies m.timeout itself; don't apply it again here too, since a
 	// child context can't outlive its parent - doing so would start the whole monitoring
@@ -192,25 +228,20 @@ func (m *Monitor) ExecuteAndWait(ctx context.Context, logger logr.Logger, reques
 
 	logger.Info("Job submitted successfully", "prowExecutionID", prowExecutionID, "jobName", request.JobName)
 
-	err = m.WaitForCompletion(ctx, logger, prowExecutionID)
-	if err == nil || !m.allowEV2Retry {
-		return err
+	outcome := m.waitForCompletion(ctx, logger, prowExecutionID)
+	if outcome.Err == nil || !m.allowEV2Retry || !outcome.Retryable {
+		return outcome.Err
 	}
 
-	var failedErr *JobFailedError
-	if !errors.As(err, &failedErr) {
-		return err
-	}
-
-	retry, checkErr := m.checkRetryMarker(ctx, failedErr.JobURL, m.maxAutoRetryFailures)
+	retry, checkErr := m.checkRetryMarker(ctx, outcome.JobURL, m.maxAutoRetryFailures)
 	if checkErr != nil {
-		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, failing normally", "prowExecutionID", failedErr.ProwExecutionID)
-		return err
+		logger.Error(checkErr, "Failed to inspect finished.json for the EV2 retry signal, failing normally", "prowExecutionID", prowExecutionID)
+		return outcome.Err
 	}
 	if !retry {
-		return err
+		return outcome.Err
 	}
 
-	logger.Info("finished.json marks the run as safe to retry, failing with the EV2-retryable marker so the gating step's automatedRetry re-runs it", "prowExecutionID", failedErr.ProwExecutionID, "jobURL", failedErr.JobURL)
-	return &EV2RetryableError{Cause: err}
+	logger.Info("finished.json marks the run as safe to retry, failing with the EV2-retryable marker so the gating step's automatedRetry re-runs it", "prowExecutionID", prowExecutionID, "jobURL", outcome.JobURL)
+	return &EV2RetryableError{Cause: outcome.Err}
 }

--- a/tools/prow-job-executor/prowjob/monitor_test.go
+++ b/tools/prow-job-executor/prowjob/monitor_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	prowgangway "sigs.k8s.io/prow/pkg/gangway"
+)
+
+// newTestServers spins up fake gangway (submit) and prow (status) endpoints.
+// Each submission gets a sequentially numbered job ID ("job-1", "job-2", ...)
+// whose reported state is taken from states, in order (the last entry repeats
+// once exhausted).
+func newTestServers(t *testing.T, states []string) (client *Client, submitCount *int32) {
+	t.Helper()
+
+	var submits int32
+	var prowSrv *httptest.Server
+
+	gangwaySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&submits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"id":"job-%d"}`, n)
+	}))
+	t.Cleanup(gangwaySrv.Close)
+
+	prowSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("prowjob")
+		var idx int
+		_, _ = fmt.Sscanf(id, "job-%d", &idx)
+		idx-- // job-1 -> states[0]
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(states) {
+			idx = len(states) - 1
+		}
+		state := states[idx]
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "status:\n  state: %s\n  url: https://prow.ci.openshift.org/view/gs/bucket/%s\nspec:\n  job: test-job\n", state, id)
+	}))
+	t.Cleanup(prowSrv.Close)
+
+	c := NewClient("test-token", gangwaySrv.URL, prowSrv.URL)
+	return c, &submits
+}
+
+func TestExecuteAndWaitFailsWithMarkerWhenEligible(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
+
+	var markerChecks int32
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
+		atomic.AddInt32(&markerChecks, 1)
+		if !strings.Contains(jobURL, "job-1") {
+			t.Fatalf("expected marker check against the failed job, got %q", jobURL)
+		}
+		return true, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected an error even when the failure is retry-eligible - prow-job-executor never resubmits the job itself")
+	}
+	var retryable *EV2RetryableError
+	if !errors.As(err, &retryable) {
+		t.Fatalf("expected an EV2RetryableError so EV2's automatedRetry can match on it, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), EV2RetryableMarker) {
+		t.Fatalf("expected the error text to contain %q, got %q", EV2RetryableMarker, err.Error())
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission (prow-job-executor must not resubmit), got %d", got)
+	}
+	if got := atomic.LoadInt32(&markerChecks); got != 1 {
+		t.Fatalf("expected exactly 1 marker check, got %d", got)
+	}
+}
+
+func TestExecuteAndWaitFailsPlainWhenMarkerAbsent(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
+
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, true, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
+		return false, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected the job failure to propagate when no marker is found, got nil")
+	}
+	var retryable *EV2RetryableError
+	if errors.As(err, &retryable) {
+		t.Fatalf("expected a plain error (not EV2-retryable) when the failure is not eligible, got: %v", err)
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission, got %d", got)
+	}
+}
+
+func TestExecuteAndWaitSkipsMarkerCheckWhenNotAllowed(t *testing.T) {
+	client, submitCount := newTestServers(t, []string{"failure"})
+
+	m := NewMonitor(client, time.Millisecond, time.Second, false, true, false, DefaultMaxEV2AutoRetryFailures)
+	m.checkRetryMarker = func(ctx context.Context, jobURL string, maxAutoRetryFailures int) (bool, error) {
+		t.Fatal("checkRetryMarker should not be called when allowEV2Retry is false")
+		return false, nil
+	}
+
+	err := m.ExecuteAndWait(testContext(), logr.Discard(), &prowgangway.CreateJobExecutionRequest{})
+	if err == nil {
+		t.Fatal("expected the job failure to propagate")
+	}
+	if got := atomic.LoadInt32(submitCount); got != 1 {
+		t.Fatalf("expected exactly 1 submission, got %d", got)
+	}
+}

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -135,9 +135,15 @@ func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string, maxAutoRet
 		return false, fmt.Errorf("failed to fetch finished.json %q: unexpected status %d", rawURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFinishedJSONBytes))
+	// Read one byte past the cap so we can distinguish "fits within the cap" from
+	// "was truncated" - io.LimitReader alone would silently accept an oversized body as
+	// long as valid JSON appears before the limit, which defeats the fail-closed intent.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFinishedJSONBytes+1))
 	if err != nil {
 		return false, fmt.Errorf("failed to read finished.json %q: %w", rawURL, err)
+	}
+	if len(body) > maxFinishedJSONBytes {
+		return false, fmt.Errorf("finished.json %q exceeds %d byte limit", rawURL, maxFinishedJSONBytes)
 	}
 
 	var finished finishedJSON
@@ -145,26 +151,40 @@ func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string, maxAutoRet
 		return false, fmt.Errorf("failed to decode finished.json %q: %w", rawURL, err)
 	}
 
-	failed := stringSliceFromMetadata(finished.Metadata, ev2FailedTestsKey)
-	allowRetry := stringSliceFromMetadata(finished.Metadata, ev2AllowRetryTestsKey)
+	failed, ok := stringSliceFromMetadata(finished.Metadata, ev2FailedTestsKey)
+	if !ok {
+		return false, fmt.Errorf("finished.json %q metadata key %q is present but not a list of strings", rawURL, ev2FailedTestsKey)
+	}
+	allowRetry, ok := stringSliceFromMetadata(finished.Metadata, ev2AllowRetryTestsKey)
+	if !ok {
+		return false, fmt.Errorf("finished.json %q metadata key %q is present but not a list of strings", rawURL, ev2AllowRetryTestsKey)
+	}
 	return ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures), nil
 }
 
 // stringSliceFromMetadata extracts a []string out of finished.json's loosely-typed
-// metadata map for the given key, tolerating a missing or malformed key by returning nil -
-// callers treat a missing list the same as an empty one.
-func stringSliceFromMetadata(metadata map[string]interface{}, key string) []string {
-	raw, ok := metadata[key].([]interface{})
+// metadata map for the given key. A missing key returns (nil, true) - callers treat an
+// absent list the same as an empty one. A key that's present but not a list of strings
+// returns (nil, false) so the caller can fail closed instead of silently dropping the
+// non-string elements and understating the failure count.
+func stringSliceFromMetadata(metadata map[string]interface{}, key string) ([]string, bool) {
+	rawVal, present := metadata[key]
+	if !present {
+		return nil, true
+	}
+	raw, ok := rawVal.([]interface{})
 	if !ok {
-		return nil
+		return nil, false
 	}
 	out := make([]string, 0, len(raw))
 	for _, v := range raw {
-		if s, ok := v.(string); ok {
-			out = append(out, s)
+		s, ok := v.(string)
+		if !ok {
+			return nil, false
 		}
+		out = append(out, s)
 	}
-	return out
+	return out, true
 }
 
 // ev2RetryEligible decides whether a finished run qualifies for an automatic EV2 gating

--- a/tools/prow-job-executor/prowjob/retrymarker.go
+++ b/tools/prow-job-executor/prowjob/retrymarker.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// ev2FailedTestsKey and ev2AllowRetryTestsKey are the finished.json metadata keys that the
+// ARO-HCP E2E test binary (aro-hcp-tests, see AROSLSRE-1721) always writes once a run
+// finishes: the full list of failed spec names, and the subset of those that were labeled
+// allow-retry (a known, tracked issue with a fix already committed to). aro-hcp-tests
+// writes both keys into $ARTIFACT_DIR/metadata.json, which Prow's sidecar merges into the
+// job's finished.json under the top-level "metadata" object - the standard Prow
+// custom-metadata mechanism, so no log scraping is involved.
+//
+// aro-hcp-tests only reports these raw facts, even when nothing failed (both lists empty);
+// it is prow-job-executor's job (ev2RetryEligible below) to decide whether the shape of a
+// failure is narrow enough to safely auto-retry. Keeping the policy here, rather than baked
+// into an ARO-HCP release, means the retry threshold can be tuned without an ARO-HCP
+// rebuild, and an absent key unambiguously means "this step never ran" rather than
+// "the run failed but wasn't retry-eligible".
+const (
+	ev2FailedTestsKey     = "ev2-failed-tests"
+	ev2AllowRetryTestsKey = "ev2-allow-retry-tests"
+)
+
+// DefaultMaxEV2AutoRetryFailures caps how many failed tests a run may have and still
+// qualify for an automatic EV2 gating retry. If more tests than this fail, or any failure
+// isn't labeled allow-retry, we stay silent and let the gate fail normally for a human to
+// triage. Overridable via Monitor's maxAutoRetryFailures field (see the
+// --max-ev2-auto-retry-failures flag).
+const DefaultMaxEV2AutoRetryFailures = 2
+
+// maxFinishedJSONBytes bounds how much of finished.json we'll read. The file
+// is a small, flat JSON document; anything near this size indicates something
+// unexpected and we'd rather fail closed than buffer an unbounded response.
+const maxFinishedJSONBytes = 1 << 20 // 1 MiB
+
+// finishedJSONFetchTimeout bounds a single finished.json fetch, independent of
+// the overall job-monitoring timeout.
+const finishedJSONFetchTimeout = 30 * time.Second
+
+// finishedJSON is the subset of Prow's finished.json (produced by the sidecar
+// utility, see sigs.k8s.io/prow/pkg/sidecar and the testgrid metadata.Finished
+// type) that we need: the free-form metadata object merged in from each
+// step's $ARTIFACT_DIR/metadata.json.
+type finishedJSON struct {
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+// finishedJSONURLFromViewURL converts a Prow Deck "view" URL (the one
+// reported in ProwJob.Status.URL, e.g.
+// https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/<job>/<build>)
+// into finished.json's public GCS URL, e.g.
+// https://storage.googleapis.com/origin-ci-test/logs/<job>/<build>/finished.json.
+func finishedJSONURLFromViewURL(viewURL string) (string, error) {
+	if viewURL == "" {
+		return "", fmt.Errorf("job has no status URL, cannot locate its finished.json")
+	}
+
+	u, err := url.Parse(viewURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse job status URL %q: %w", viewURL, err)
+	}
+
+	const viewPrefix = "/view/gs/"
+	if !strings.HasPrefix(u.Path, viewPrefix) {
+		return "", fmt.Errorf("job status URL %q does not look like a GCS Prow view URL (missing %q prefix)", viewURL, viewPrefix)
+	}
+
+	gcsPath := strings.Trim(strings.TrimPrefix(u.Path, viewPrefix), "/")
+	if gcsPath == "" {
+		return "", fmt.Errorf("job status URL %q has an empty GCS path after the %q prefix", viewURL, viewPrefix)
+	}
+	return fmt.Sprintf("https://storage.googleapis.com/%s/finished.json", gcsPath), nil
+}
+
+// jobAllowsEV2Retry fetches finished.json for the job reported at viewURL and reports
+// whether its ev2FailedTestsKey/ev2AllowRetryTestsKey metadata qualifies for an automatic
+// EV2 gating retry, per ev2RetryEligible.
+func jobAllowsEV2Retry(ctx context.Context, viewURL string, maxAutoRetryFailures int) (bool, error) {
+	rawURL, err := finishedJSONURLFromViewURL(viewURL)
+	if err != nil {
+		return false, err
+	}
+	return fetchFinishedJSONAllowsRetry(ctx, rawURL, maxAutoRetryFailures)
+}
+
+// fetchFinishedJSONAllowsRetry downloads rawURL as a finished.json document and reports
+// whether its metadata qualifies for an automatic EV2 gating retry. Split out from
+// jobAllowsEV2Retry so the HTTP fetch/parse logic can be tested against a local httptest
+// server, independent of GCS URL construction.
+func fetchFinishedJSONAllowsRetry(ctx context.Context, rawURL string, maxAutoRetryFailures int) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, finishedJSONFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create finished.json request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch finished.json %q: %w", rawURL, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logr.FromContextOrDiscard(ctx).Error(err, "failed to close body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("failed to fetch finished.json %q: unexpected status %d", rawURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFinishedJSONBytes))
+	if err != nil {
+		return false, fmt.Errorf("failed to read finished.json %q: %w", rawURL, err)
+	}
+
+	var finished finishedJSON
+	if err := json.Unmarshal(body, &finished); err != nil {
+		return false, fmt.Errorf("failed to decode finished.json %q: %w", rawURL, err)
+	}
+
+	failed := stringSliceFromMetadata(finished.Metadata, ev2FailedTestsKey)
+	allowRetry := stringSliceFromMetadata(finished.Metadata, ev2AllowRetryTestsKey)
+	return ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures), nil
+}
+
+// stringSliceFromMetadata extracts a []string out of finished.json's loosely-typed
+// metadata map for the given key, tolerating a missing or malformed key by returning nil -
+// callers treat a missing list the same as an empty one.
+func stringSliceFromMetadata(metadata map[string]interface{}, key string) []string {
+	raw, ok := metadata[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ev2RetryEligible decides whether a finished run qualifies for an automatic EV2 gating
+// retry, given the raw facts aro-hcp-tests reported: every test name that failed, and the
+// subset of those that were labeled allow-retry (a known, tracked issue). This is the
+// whole eligibility policy, kept separate from the HTTP fetch/parse logic above so it can
+// be tested directly.
+//
+// A run qualifies only when it failed at all, no more than maxAutoRetryFailures tests
+// failed, and every failure was labeled allow-retry. Any other shape - too many failures,
+// or even a single failure not carrying the label - disqualifies the whole run, so the
+// gate fails normally and a human triages it.
+func ev2RetryEligible(failed, allowRetry []string, maxAutoRetryFailures int) bool {
+	if len(failed) == 0 || len(failed) > maxAutoRetryFailures {
+		return false
+	}
+	allowRetrySet := make(map[string]bool, len(allowRetry))
+	for _, name := range allowRetry {
+		allowRetrySet[name] = true
+	}
+	for _, name := range failed {
+		if !allowRetrySet[name] {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -176,9 +176,10 @@ func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 }
 
 func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
-	// A finished.json far larger than any real one should still be read (up to
-	// the cap) without hanging or OOMing, and simply fail to parse as JSON
-	// once truncated - proving the size cap is actually enforced.
+	// A finished.json far larger than the size cap should be rejected outright:
+	// fetchFinishedJSONAllowsRetry explicitly errors once the cap is exceeded,
+	// before ever attempting to JSON-decode the body - proving the cap is
+	// enforced as a hard limit, not just an incidental truncation.
 	huge := `{"metadata":{"padding":"` + strings.Repeat("x", maxFinishedJSONBytes+1024) + `","ev2-failed-tests":["spec A"]}}`
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +190,7 @@ func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
 
 	_, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL, DefaultMaxEV2AutoRetryFailures)
 	if err == nil {
-		t.Fatal("expected an error from truncated/invalid JSON, got nil")
+		t.Fatal("expected an error from the oversized body, got nil")
 	}
 }
 

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -125,10 +125,16 @@ func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "metadata key wrong type is treated as absent",
+			name:       "metadata key wrong type fails closed",
 			statusCode: http.StatusOK,
 			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":"spec A"}}`,
-			want:       false,
+			wantErr:    true,
+		},
+		{
+			name:       "metadata list with a non-string element fails closed",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A", 1]}}`,
+			wantErr:    true,
 		},
 		{
 			name:       "non-200 status is an error",

--- a/tools/prow-job-executor/prowjob/retrymarker_test.go
+++ b/tools/prow-job-executor/prowjob/retrymarker_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjob
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFinishedJSONURLFromViewURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		viewURL string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "typical prow deck view URL",
+			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/12345/finished.json",
+		},
+		{
+			name:    "trailing slash is trimmed",
+			viewURL: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/some-job/1/",
+			want:    "https://storage.googleapis.com/origin-ci-test/logs/some-job/1/finished.json",
+		},
+		{
+			name:    "empty URL is an error",
+			viewURL: "",
+			wantErr: true,
+		},
+		{
+			name:    "missing /view/gs/ prefix is an error",
+			viewURL: "https://prow.ci.openshift.org/something-else/origin-ci-test/logs/some-job/1",
+			wantErr: true,
+		},
+		{
+			name:    "empty GCS path after /view/gs/ prefix is an error",
+			viewURL: "https://prow.ci.openshift.org/view/gs/",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := finishedJSONURLFromViewURL(tc.viewURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got URL %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchFinishedJSONAllowsRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "single allow-retry failure qualifies",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A"],"ev2-allow-retry-tests":["spec A"],"pod":"abc"}}`,
+			want:       true,
+		},
+		{
+			name:       "failures at the cap still qualify",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B"],"ev2-allow-retry-tests":["spec A","spec B"]}}`,
+			want:       true,
+		},
+		{
+			name:       "one failure over the cap disqualifies",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B","spec C"],"ev2-allow-retry-tests":["spec A","spec B","spec C"]}}`,
+			want:       false,
+		},
+		{
+			name:       "an unlabeled failure disqualifies the whole run",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":["spec A","spec B"],"ev2-allow-retry-tests":["spec A"]}}`,
+			want:       false,
+		},
+		{
+			name:       "metadata keys absent means no failures reported",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":true,"result":"SUCCESS","metadata":{"pod":"abc"}}`,
+			want:       false,
+		},
+		{
+			name:       "empty failed-tests list is a clean run",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":true,"result":"SUCCESS","metadata":{"ev2-failed-tests":[],"ev2-allow-retry-tests":[]}}`,
+			want:       false,
+		},
+		{
+			name:       "no metadata object at all",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE"}`,
+			want:       false,
+		},
+		{
+			name:       "metadata key wrong type is treated as absent",
+			statusCode: http.StatusOK,
+			body:       `{"timestamp":1,"passed":false,"result":"FAILURE","metadata":{"ev2-failed-tests":"spec A"}}`,
+			want:       false,
+		},
+		{
+			name:       "non-200 status is an error",
+			statusCode: http.StatusNotFound,
+			body:       "not found",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid JSON is an error",
+			statusCode: http.StatusOK,
+			body:       `{not json`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL, DefaultMaxEV2AutoRetryFailures)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchFinishedJSONAllowsRetryRejectsOversizedBody(t *testing.T) {
+	// A finished.json far larger than any real one should still be read (up to
+	// the cap) without hanging or OOMing, and simply fail to parse as JSON
+	// once truncated - proving the size cap is actually enforced.
+	huge := `{"metadata":{"padding":"` + strings.Repeat("x", maxFinishedJSONBytes+1024) + `","ev2-failed-tests":["spec A"]}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	_, err := fetchFinishedJSONAllowsRetry(testContext(), srv.URL, DefaultMaxEV2AutoRetryFailures)
+	if err == nil {
+		t.Fatal("expected an error from truncated/invalid JSON, got nil")
+	}
+}
+
+func TestEV2RetryEligible(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		failed     []string
+		allowRetry []string
+		maxFailure int
+		want       bool
+	}{
+		{
+			name:       "clean run does not qualify",
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "single labeled failure qualifies",
+			failed:     []string{"spec A"},
+			allowRetry: []string{"spec A"},
+			maxFailure: 2,
+			want:       true,
+		},
+		{
+			name:       "failures at the cap still qualify",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A", "spec B"},
+			maxFailure: 2,
+			want:       true,
+		},
+		{
+			name:       "one failure over the cap disqualifies",
+			failed:     []string{"spec A", "spec B", "spec C"},
+			allowRetry: []string{"spec A", "spec B", "spec C"},
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "an unlabeled failure disqualifies the whole run",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A"},
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "a lone unlabeled failure disqualifies",
+			failed:     []string{"spec A"},
+			allowRetry: nil,
+			maxFailure: 2,
+			want:       false,
+		},
+		{
+			name:       "a lower configured cap tightens eligibility",
+			failed:     []string{"spec A", "spec B"},
+			allowRetry: []string{"spec A", "spec B"},
+			maxFailure: 1,
+			want:       false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ev2RetryEligible(tc.failed, tc.allowRetry, tc.maxFailure); got != tc.want {
+				t.Fatalf("ev2RetryEligible(%v, %v, %d) = %v, want %v", tc.failed, tc.allowRetry, tc.maxFailure, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Jira: [AROSLSRE-1721](https://redhat.atlassian.net/browse/AROSLSRE-1721)

### What

Add an EV2 auto-retry to `prow-job-executor`'s gating path. When a gated job fails and its `finished.json` metadata shows only known, deliberately-labeled tests failed (up to a small cap), the executor fails with a distinct, matchable error so the EV2 gating step's own `automatedRetry` re-runs the whole step. `prow-job-executor` never resubmits the job itself, it only decides whether the failure qualifies.

`prowjob.Monitor` gains an `allowEV2Retry` flag and a `JobFailedError` type that distinguishes real test failures from infra errors/aborts, which are never auto-retried. `prowjob/retrymarker.go` converts a Prow view URL into its GCS `finished.json` URL, fetches it (size-capped), and reads the `ev2-failed-tests` / `ev2-allow-retry-tests` metadata lists to decide eligibility. When eligible, `ExecuteAndWait` wraps the failure in an `EV2RetryableError` whose text always contains `EV2RetryableMarker`, a fixed substring the EV2 gating step's `pipeline.yaml` matches via `automatedRetry.errorContainsAny`.

New CLI flags: `--allow-ev2-retry` (execute path only) and `--max-ev2-auto-retry-failures` (default `2`, now validated to be greater than 0 when retry is enabled). The read-only `monitor` subcommand always passes `allowEV2Retry=false`.

### Why

Right now, when a small number of E2E tests fail on a known, already-tracked issue during an EV2 Stage/Prod gating step, a human has to notice the failure, open the Prow output, and manually retrigger the rollout. This lets the gating step retry that narrow, already-understood failure class on its own, cutting the latency and churn on every rollout that hits it.

### Testing

```
go build ./...
go vet ./...
go test -race -count=1 ./...
```

All pass in `tools/prow-job-executor`.
